### PR TITLE
Allow manual input of post meta keys

### DIFF
--- a/src/components/post-meta-control.js
+++ b/src/components/post-meta-control.js
@@ -1,7 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { SelectControl, TextControl, Button } from '@wordpress/components';
+import {
+	SelectControl,
+	TextControl,
+	Button,
+	FormTokenField,
+	BaseControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 const compareMetaOptions = [
@@ -23,8 +29,6 @@ const compareMetaOptions = [
 	'RLIKE',
 ];
 
-const updateQueryParams = () => {};
-
 export const PostMetaControl = ( {
 	registeredMetaKeys,
 	id,
@@ -38,6 +42,7 @@ export const PostMetaControl = ( {
 	const activeQuery = queries.find( ( query ) => query.id === id );
 
 	/**
+	 * Update a query param.
 	 *
 	 * @param {*} queries
 	 * @param {*} queryId
@@ -59,37 +64,40 @@ export const PostMetaControl = ( {
 
 	return (
 		<>
-			<SelectControl
-				label={ __( 'Meta Key', 'advanced-query-loop' ) }
-				value={ activeQuery.meta_key }
-				options={ [
-					{ label: 'Choose Meta', value: '' },
-					...Object.keys( registeredMetaKeys ).map(
-						( selectedKey ) => {
-							return {
-								label: selectedKey,
-								value: selectedKey,
-							};
-						}
-					),
-				] }
-				onChange={ ( newMeta ) => {
-					setAttributes( {
-						query: {
-							...attributes.query,
-							meta_query: {
-								...attributes.query.meta_query,
-								queries: updateQueryParam(
-									queries,
-									id,
-									'meta_key',
-									newMeta
-								),
+			<BaseControl
+				help={ __(
+					'Start typing to search for a meta key or manually enter one.',
+					'advanced-query-loop'
+				) }
+			>
+				<FormTokenField
+					label={ __( 'Meta Key', 'advanced-query-loop' ) }
+					value={
+						activeQuery?.meta_key?.length
+							? [ activeQuery.meta_key ]
+							: []
+					}
+					__experimentalShowHowTo={ false }
+					suggestions={ registeredMetaKeys }
+					maxLength={ 1 }
+					onChange={ ( newMeta ) => {
+						setAttributes( {
+							query: {
+								...attributes.query,
+								meta_query: {
+									...attributes.query.meta_query,
+									queries: updateQueryParam(
+										queries,
+										id,
+										'meta_key',
+										newMeta[ 0 ]
+									),
+								},
 							},
-						},
-					} );
-				} }
-			/>
+						} );
+					} }
+				/>
+			</BaseControl>
 			<TextControl
 				label={ __( 'Meta Value', 'advanced-query-loop' ) }
 				value={ activeQuery.meta_value }

--- a/src/components/post-meta-query-controls.js
+++ b/src/components/post-meta-query-controls.js
@@ -31,7 +31,7 @@ export const PostMetaQueryControls = ( { attributes, setAttributes } ) => {
 
 	const [ selectedPostType ] = useState( postType );
 
-	const registeredMetaKeys = records?.[ 0 ]?.meta || {};
+	const registeredMeta = records?.[ 0 ]?.meta || {};
 
 	useEffect( () => {
 		// If the post type changes, reset the meta query.
@@ -47,103 +47,94 @@ export const PostMetaQueryControls = ( { attributes, setAttributes } ) => {
 
 	return (
 		<PanelBody title={ __( 'Post Meta Query', 'advanced-query-loop' ) }>
-			{ Object.keys( registeredMetaKeys ).length < 1 ? (
-				<p>
-					{ __(
-						'This post type has no registered post meta to query',
-						'advanced-query-loop'
-					) }
-				</p>
-			) : (
-				<>
-					{ queries.length > 1 && (
-						<SelectControl
-							label={ __(
-								'Query Relationship',
-								'advanced-query-loop'
-							) }
-							value={ relationFromQuery }
-							options={ [
-								{ label: 'Choose relationship', value: '' },
-								{ label: 'AND', value: 'AND' },
-								{ label: 'OR', value: 'OR' },
-							] }
-							onChange={ ( relation ) =>
-								setAttributes( {
-									query: {
-										...attributes.query,
-										meta_query: {
-											...attributes.query.meta_query,
-											relation,
-										},
-									},
-								} )
-							}
-						/>
-					) }
-
-					{ queries.length < 1 && (
-						<p>
-							{ __(
-								'Add a meta query to select post meta to query',
-								'advanced-query-loop'
-							) }
-						</p>
-					) }
-
-					{ queries.map(
-						( {
-							id,
-							meta_key: metaKey,
-							meta_value: metaValue,
-							compare,
-						} ) => {
-							return (
-								<PanelBody key={ id }>
-									<PostMetaControl
-										id={ id }
-										metaKey={ metaKey }
-										metaValue={ metaValue }
-										metaCompare={ compare }
-										registeredMetaKeys={
-											registeredMetaKeys
-										}
-										queries={ queries }
-										attributes={ attributes }
-										setAttributes={ setAttributes }
-									/>
-								</PanelBody>
-							);
-						}
-					) }
-					<Button
-						isSmall
-						variant="primary"
-						onClick={ () => {
-							const newQueries = [
-								...queries,
-								{
-									id: uuidv4(),
-									meta_key: '',
-									meta_value: '',
-									meta_compare: '',
-								},
-							];
+			<>
+				{ queries.length > 1 && (
+					<SelectControl
+						label={ __(
+							'Query Relationship',
+							'advanced-query-loop'
+						) }
+						value={ relationFromQuery }
+						options={ [
+							{ label: 'Choose relationship', value: '' },
+							{ label: 'AND', value: 'AND' },
+							{ label: 'OR', value: 'OR' },
+						] }
+						onChange={ ( relation ) =>
 							setAttributes( {
 								query: {
 									...attributes.query,
 									meta_query: {
 										...attributes.query.meta_query,
-										queries: newQueries,
+										relation,
 									},
 								},
-							} );
-						} }
-					>
-						{ __( 'Add meta query', 'advanced-query-loop' ) }
-					</Button>
-				</>
-			) }
+							} )
+						}
+					/>
+				) }
+
+				{ queries.length < 1 && (
+					<p>
+						{ __(
+							'Add a meta query to select post meta to query',
+							'advanced-query-loop'
+						) }
+					</p>
+				) }
+
+				{ queries.map(
+					( {
+						id,
+						meta_key: metaKey,
+						meta_value: metaValue,
+						compare,
+					} ) => {
+						return (
+							<PanelBody key={ id }>
+								<PostMetaControl
+									id={ id }
+									metaKey={ metaKey }
+									metaValue={ metaValue }
+									metaCompare={ compare }
+									registeredMetaKeys={ Object.keys(
+										registeredMeta
+									) }
+									queries={ queries }
+									attributes={ attributes }
+									setAttributes={ setAttributes }
+								/>
+							</PanelBody>
+						);
+					}
+				) }
+				<Button
+					isSmall
+					variant="primary"
+					onClick={ () => {
+						const newQueries = [
+							...queries,
+							{
+								id: uuidv4(),
+								meta_key: '',
+								meta_value: '',
+								meta_compare: '',
+							},
+						];
+						setAttributes( {
+							query: {
+								...attributes.query,
+								meta_query: {
+									...attributes.query.meta_query,
+									queries: newQueries,
+								},
+							},
+						} );
+					} }
+				>
+					{ __( 'Add meta query', 'advanced-query-loop' ) }
+				</Button>
+			</>
 		</PanelBody>
 	);
 };


### PR DESCRIPTION
Changes the meta key select to use FormTokenField to be able to select from existing or manually input a post meta key.

Fixes #7 