### PR TITLE
Add transform to allow converting existing Query Loop blocks to AQL instances

### DIFF
--- a/src/variations/index.js
+++ b/src/variations/index.js
@@ -3,7 +3,6 @@
  */
 import { registerBlockVariation } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
-
 /**
  * Internal dependencies
  */
@@ -21,5 +20,5 @@ registerBlockVariation( 'core/query', {
 	attributes: {
 		namespace: AQL,
 	},
-	scope: [ 'inserter' ],
+	scope: [ 'inserter', 'transform' ],
 } );


### PR DESCRIPTION
This uses the built-in `transform` option for the `scope` property and appears in the sidebar

![transform](https://github.com/ryanwelcher/advanced-query-loop/assets/1259027/c2ff7fcc-6ac4-4ec6-ac63-e9ff15dd5629)
