### PR TITLE
Add Current Post Exclusion

### DIFF
--- a/includes/query-loop.php
+++ b/includes/query-loop.php
@@ -45,16 +45,9 @@ function parse_meta_query( $meta_query_data ) {
 function get_exclude_ids( $attributes ) {
 	$exclude_ids = array();
 
-	// Exclude Posts by ID.
-	if ( isset( $attributes['exclude_posts'] ) && ! empty( $attributes['exclude_posts'] ) ) {
-		$exclude_ids = $attributes['exclude_posts'];
-	}
-
 	// Exclude Current Post.
 	if ( isset( $attributes['exclude_current'] ) && boolval( $attributes['exclude_current'] ) ) {
-		if ( ! in_array( $attributes['exclude_current'], $exclude_ids ) ) {
-			array_push( $exclude_ids, $attributes['exclude_current']);
-		}
+		array_push( $exclude_ids, $attributes['exclude_current']);
 	}
 
 	return $exclude_ids;
@@ -254,11 +247,9 @@ function add_custom_query_params( $args, $request ) {
 	}
 
 	// Exclusion Related.
-	$exclude_posts = $request->get_param( 'exclude_posts' );
 	$exclude_current = $request->get_param( 'exclude_current' );
-	if ( $exclude_posts || $exclude_current ) {
+	if ( $exclude_current ) {
 		$attributes = array(
-			'exclude_posts' => $exclude_posts,
 			'exclude_current' => $exclude_current,
 		);
 

--- a/includes/query-loop.php
+++ b/includes/query-loop.php
@@ -36,6 +36,29 @@ function parse_meta_query( $meta_query_data ) {
 	return array_filter( $meta_queries );
 }
 
+/**
+ * Returns an array with Post IDs that should be excluded from the Query.
+ * 
+ * @param array
+ * @return array
+ */
+function get_exclude_ids( $attributes ) {
+	$exclude_ids = array();
+
+	// Exclude Posts by ID
+	if ( isset( $attributes['exclude_posts'] ) && ! empty( $attributes['exclude_posts'] ) ) {
+		$exclude_ids = $attributes['exclude_posts'];
+	}
+
+	// Exclude Current Post
+	if ( isset( $attributes['exclude_current'] ) && boolval($attributes['exclude_current']) ) {
+		if (!in_array($attributes['exclude_current'], $exclude_ids)) {
+			array_push( $exclude_ids, $attributes['exclude_current']);
+		}
+	}
+
+	return $exclude_ids;
+}
 
 
 
@@ -71,6 +94,12 @@ function parse_meta_query( $meta_query_data ) {
 						// Post Related.
 						if ( isset( $custom_query['multiple_posts'] ) && ! empty( $custom_query['multiple_posts'] ) ) {
 							$custom_args['post_type'] = array_merge( array( $default_query['post_type'] ), $custom_query['multiple_posts'] );
+						}
+
+						// Exclude Posts.
+						$exclude_ids = get_exclude_ids( $custom_query );
+						if (  ! empty( $exclude_ids ) ) {
+							$custom_args['post__not_in'] = $exclude_ids;
 						}
 
 						// Check for meta queries.
@@ -195,6 +224,18 @@ function add_custom_query_params( $args, $request ) {
 	$multiple_post_types = $request->get_param( 'multiple_posts' );
 	if ( $multiple_post_types ) {
 		$custom_args['post_type'] = array_merge( array( $args['post_type'] ), $multiple_post_types );
+	}
+
+	// Exclusion Related.
+	$exclude_posts = $request->get_param( 'exclude_posts' );
+	$exclude_current = $request->get_param( 'exclude_current' );
+	if ( $exclude_posts || $exclude_current ) {
+		$attributes = array(
+			'exclude_posts' => $exclude_posts,
+			'exclude_current' => $exclude_current,
+		);
+
+		$custom_args['post__not_in'] = get_exclude_ids($attributes);
 	}
 
 	// Meta related.

--- a/includes/query-loop.php
+++ b/includes/query-loop.php
@@ -45,14 +45,14 @@ function parse_meta_query( $meta_query_data ) {
 function get_exclude_ids( $attributes ) {
 	$exclude_ids = array();
 
-	// Exclude Posts by ID
+	// Exclude Posts by ID.
 	if ( isset( $attributes['exclude_posts'] ) && ! empty( $attributes['exclude_posts'] ) ) {
 		$exclude_ids = $attributes['exclude_posts'];
 	}
 
-	// Exclude Current Post
-	if ( isset( $attributes['exclude_current'] ) && boolval($attributes['exclude_current']) ) {
-		if (!in_array($attributes['exclude_current'], $exclude_ids)) {
+	// Exclude Current Post.
+	if ( isset( $attributes['exclude_current'] ) && boolval( $attributes['exclude_current'] ) ) {
+		if ( ! in_array( $attributes['exclude_current'], $exclude_ids ) ) {
 			array_push( $exclude_ids, $attributes['exclude_current']);
 		}
 	}
@@ -235,7 +235,7 @@ function add_custom_query_params( $args, $request ) {
 			'exclude_current' => $exclude_current,
 		);
 
-		$custom_args['post__not_in'] = get_exclude_ids($attributes);
+		$custom_args['post__not_in'] = get_exclude_ids( $attributes );
 	}
 
 	// Meta related.

--- a/src/components/post-exclude-controls.js
+++ b/src/components/post-exclude-controls.js
@@ -1,12 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	PanelBody,
-	ToggleControl,
-	FormTokenField,
-	BaseControl,
-} from '@wordpress/components';
+import { ToggleControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -16,87 +11,19 @@ import { __ } from '@wordpress/i18n';
  * @return {Element} PostExcludeControls
  */
 export const PostExcludeControls = ( { attributes, setAttributes } ) => {
-	const {
-		query: {
-			exclude_posts: excludePosts = [],
-			exclude_current: excludeCurrent,
-			postType,
-			multiple_posts: multiplePosts = [],
-		} = {},
-	} = attributes;
+	const { query: { exclude_current: excludeCurrent } = {} } = attributes;
 
 	const currentPost = useSelect( ( select ) => {
 		return select( 'core/editor' ).getCurrentPost();
 	}, [] );
 
-	// Get the posts for all post types used in the query.
-	const posts = useSelect(
-		( select ) => {
-			const { getEntityRecords } = select( 'core' );
-
-			// Fetch posts for each post type and combine them into one array
-			return [ ...multiplePosts, postType ].reduce(
-				( accumulator, postType ) => {
-					// Depending on the number of posts this could take a while, since we can't paginate here
-					const records = getEntityRecords( 'postType', postType, {
-						per_page: -1,
-					} );
-					return [ ...accumulator, ...( records || [] ) ];
-				},
-				[]
-			);
-		},
-		[ postType, multiplePosts ]
-	);
-
-	// For use with flatMap(), as this lets us remove elements during a map()
-	const idToTitle = ( id ) => {
-		const post = posts.find( ( p ) => p.id === id );
-		return post ? [ post.title.rendered ] : [];
-	};
-
-	const titleToId = ( title ) => {
-		const post = posts.find( ( p ) => p.title.rendered === title );
-		return post ? [ post.id ] : [];
-	};
-
-	if ( ! currentPost || ! posts ) {
-		return (
-			<PanelBody title={ __( 'Exclude Posts', 'advanced-query-loop' ) }>
-				{ __( 'Loading…', 'advanced-query-loop' ) }
-			</PanelBody>
-		);
+	if ( ! currentPost ) {
+		return <div>{ __( 'Loading…', 'advanced-query-loop' ) }</div>;
 	}
 
 	return (
 		<>
 			<h2> { __( 'Exclude Posts', 'advanced-query-loop' ) }</h2>
-			<BaseControl
-				help={ __(
-					'Start typing to search for a post title or manually enter one.',
-					'advanced-query-loop'
-				) }
-			>
-				<FormTokenField
-					label={ __( 'Posts', 'advanced-query-loop' ) }
-					value={ excludePosts.flatMap( ( id ) => idToTitle( id ) ) }
-					suggestions={ posts.map( ( post ) => post.title.rendered ) }
-					onChange={ ( titles ) => {
-						// Converts the Titles to Post IDs before saving them
-						setAttributes( {
-							query: {
-								...attributes.query,
-								exclude_posts:
-									titles.flatMap( ( title ) =>
-										titleToId( title )
-									) || [],
-							},
-						} );
-					} }
-					__experimentalExpandOnFocus
-					__experimentalShowHowTo={ false }
-				/>
-			</BaseControl>
 			<ToggleControl
 				label={ __( 'Exclude Current Post', 'advanced-query-loop' ) }
 				checked={ !! excludeCurrent }

--- a/src/components/post-exclude-controls.js
+++ b/src/components/post-exclude-controls.js
@@ -1,0 +1,94 @@
+/**
+ * WordPress dependencies
+ */
+import { PanelBody, ToggleControl, FormTokenField, BaseControl } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * A component that lets you pick posts to be excluded from the query
+ *
+ * @return {Element} PostExcludeControls
+ */
+export const PostExcludeControls = ( { attributes, setAttributes } ) => {
+	const { query: { exclude_posts: excludePosts = [], exclude_current: excludeCurrent, postType, multiple_posts: multiplePosts = [] } = {} } = attributes;
+
+	const currentPost = useSelect( ( select ) => {
+        return select('core/editor').getCurrentPost();
+    }, [] );
+
+	// Get the posts for all post types used in the query.
+	const posts = useSelect((select) => {
+        const { getEntityRecords } = select('core');
+
+        // Fetch posts for each post type and combine them into one array
+        return [...multiplePosts, postType].reduce((accumulator, postType) => {
+			// Depending on the number of posts this could take a while, since we can't paginate here
+            const records = getEntityRecords('postType', postType, { per_page: -1 });
+            return [...accumulator, ...(records || [])];
+        }, []);
+    }, [postType, multiplePosts]);
+
+	// For use with flatMap(), as this lets us remove elements during a map()
+	const idToTitle = (id) => {
+		const post = posts.find(p => p.id === id);
+		return post ? [post.title.rendered] : [];
+	}
+
+	const titleToId = (title) => {
+		const post = posts.find(p => p.title.rendered === title);
+		return post ? [post.id] : [];
+	}
+
+	if ( ! currentPost || ! posts ) {
+		return (
+			<PanelBody
+				title={ __( 'Exclude Posts', 'advanced-query-loop' ) }
+			>
+				{ __( 'Loading…', 'advanced-query-loop' ) }
+			</PanelBody>
+		);
+	}
+
+	console.log('Posts:', excludePosts);
+
+	return (
+		<PanelBody title={ __( 'Exclude Posts', 'advanced-query-loop' ) }>
+			<BaseControl
+				help={ __(
+					'Start typing to search for a post title or manually enter one.',
+					'advanced-query-loop'
+				) }
+			>
+				<FormTokenField
+					label={ __( 'Posts', 'advanced-query-loop' ) }
+					value={ excludePosts.flatMap(id => idToTitle(id)) }
+					suggestions={ posts.map(post => post.title.rendered) }
+					onChange={ ( titles ) => {
+						// Converts the Titles to Post IDs before saving them
+						setAttributes( {
+							query: {
+								...attributes.query,
+								exclude_posts: titles.flatMap(title => titleToId(title)) || [],
+							},
+						} );
+					} }
+					__experimentalExpandOnFocus
+					__experimentalShowHowTo={ false }
+				/>
+			</BaseControl>
+			<ToggleControl
+				label={ __( 'Exclude Current Post', 'advanced-query-loop' ) }
+				checked={ !!excludeCurrent }
+				onChange={ (value) => {
+					setAttributes( {
+						query: {
+							...attributes.query,
+							exclude_current: value ? currentPost.id : 0,
+						},
+					} );
+				} }
+			/>
+		</PanelBody>
+	);
+};

--- a/src/components/post-exclude-controls.js
+++ b/src/components/post-exclude-controls.js
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { PanelBody, ToggleControl, FormTokenField, BaseControl } from '@wordpress/components';
+import {
+	PanelBody,
+	ToggleControl,
+	FormTokenField,
+	BaseControl,
+} from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -11,46 +16,57 @@ import { __ } from '@wordpress/i18n';
  * @return {Element} PostExcludeControls
  */
 export const PostExcludeControls = ( { attributes, setAttributes } ) => {
-	const { query: { exclude_posts: excludePosts = [], exclude_current: excludeCurrent, postType, multiple_posts: multiplePosts = [] } = {} } = attributes;
+	const {
+		query: {
+			exclude_posts: excludePosts = [],
+			exclude_current: excludeCurrent,
+			postType,
+			multiple_posts: multiplePosts = [],
+		} = {},
+	} = attributes;
 
 	const currentPost = useSelect( ( select ) => {
-        return select('core/editor').getCurrentPost();
-    }, [] );
+		return select( 'core/editor' ).getCurrentPost();
+	}, [] );
 
 	// Get the posts for all post types used in the query.
-	const posts = useSelect((select) => {
-        const { getEntityRecords } = select('core');
+	const posts = useSelect(
+		( select ) => {
+			const { getEntityRecords } = select( 'core' );
 
-        // Fetch posts for each post type and combine them into one array
-        return [...multiplePosts, postType].reduce((accumulator, postType) => {
-			// Depending on the number of posts this could take a while, since we can't paginate here
-            const records = getEntityRecords('postType', postType, { per_page: -1 });
-            return [...accumulator, ...(records || [])];
-        }, []);
-    }, [postType, multiplePosts]);
+			// Fetch posts for each post type and combine them into one array
+			return [ ...multiplePosts, postType ].reduce(
+				( accumulator, postType ) => {
+					// Depending on the number of posts this could take a while, since we can't paginate here
+					const records = getEntityRecords( 'postType', postType, {
+						per_page: -1,
+					} );
+					return [ ...accumulator, ...( records || [] ) ];
+				},
+				[]
+			);
+		},
+		[ postType, multiplePosts ]
+	);
 
 	// For use with flatMap(), as this lets us remove elements during a map()
-	const idToTitle = (id) => {
-		const post = posts.find(p => p.id === id);
-		return post ? [post.title.rendered] : [];
-	}
+	const idToTitle = ( id ) => {
+		const post = posts.find( ( p ) => p.id === id );
+		return post ? [ post.title.rendered ] : [];
+	};
 
-	const titleToId = (title) => {
-		const post = posts.find(p => p.title.rendered === title);
-		return post ? [post.id] : [];
-	}
+	const titleToId = ( title ) => {
+		const post = posts.find( ( p ) => p.title.rendered === title );
+		return post ? [ post.id ] : [];
+	};
 
 	if ( ! currentPost || ! posts ) {
 		return (
-			<PanelBody
-				title={ __( 'Exclude Posts', 'advanced-query-loop' ) }
-			>
+			<PanelBody title={ __( 'Exclude Posts', 'advanced-query-loop' ) }>
 				{ __( 'Loading…', 'advanced-query-loop' ) }
 			</PanelBody>
 		);
 	}
-
-	console.log('Posts:', excludePosts);
 
 	return (
 		<PanelBody title={ __( 'Exclude Posts', 'advanced-query-loop' ) }>
@@ -62,14 +78,17 @@ export const PostExcludeControls = ( { attributes, setAttributes } ) => {
 			>
 				<FormTokenField
 					label={ __( 'Posts', 'advanced-query-loop' ) }
-					value={ excludePosts.flatMap(id => idToTitle(id)) }
-					suggestions={ posts.map(post => post.title.rendered) }
+					value={ excludePosts.flatMap( ( id ) => idToTitle( id ) ) }
+					suggestions={ posts.map( ( post ) => post.title.rendered ) }
 					onChange={ ( titles ) => {
 						// Converts the Titles to Post IDs before saving them
 						setAttributes( {
 							query: {
 								...attributes.query,
-								exclude_posts: titles.flatMap(title => titleToId(title)) || [],
+								exclude_posts:
+									titles.flatMap( ( title ) =>
+										titleToId( title )
+									) || [],
 							},
 						} );
 					} }
@@ -79,8 +98,8 @@ export const PostExcludeControls = ( { attributes, setAttributes } ) => {
 			</BaseControl>
 			<ToggleControl
 				label={ __( 'Exclude Current Post', 'advanced-query-loop' ) }
-				checked={ !!excludeCurrent }
-				onChange={ (value) => {
+				checked={ !! excludeCurrent }
+				onChange={ ( value ) => {
 					setAttributes( {
 						query: {
 							...attributes.query,

--- a/src/variations/controls.js
+++ b/src/variations/controls.js
@@ -14,6 +14,7 @@ import { PostMetaQueryControls } from '../components/post-meta-query-controls';
 import { PostDateQueryControls } from '../components/post-date-query-controls';
 import { MultiplePostSelect } from '../components/multiple-post-select';
 import { PostOrderControls } from '../components/post-order-controls';
+import { PostExcludeControls } from '../components/post-exclude-controls';
 
 /**
  * Determines if the active variation is this one
@@ -48,6 +49,7 @@ const withAdvancedQueryControls = ( BlockEdit ) => ( props ) => {
 						<PostCountControls { ...props } />
 						<PostOffsetControls { ...props } />
 						<PostOrderControls { ...props } />
+						<PostExcludeControls { ...props } />
 						<PostMetaQueryControls { ...props } />
 						<PostDateQueryControls { ...props } />
 					</InspectorControls>


### PR DESCRIPTION
This PR implements two things:  
1. The possibility to specify posts that should be excluded from the query by their title.
2. An option to exclude the current post from the query.

This works across multiple Post Types.

To accomplish this, two new attributes were introduced:
1. `exclude_posts`: An array of post IDs that should be excluded
2. `exclude_current`: The current post ID, if it should be excluded, or 0, if not.

In an initial implementation, `exclude_current` was a boolean. I unfortunately found no way to access the current post ID in the context of the `rest_post_query` filter for the preview in the block editor (query-loop.php, ln. 238). Now the current ID just gets passed as an attribute.

If you have any idea how to implement this without passing the current post ID, please feel free to modify my solution.

I am quite new to WordPress development, so if I have committed any blunders, please point them out.

Closes #3 