### PR TITLE
Make date query more robust on PHP 8

### DIFF
--- a/includes/query-loop.php
+++ b/includes/query-loop.php
@@ -127,22 +127,23 @@ function get_exclude_ids( $attributes ) {
 						}
 
 						// Date queries.
-						if ( ! empty( $block_query['date_query'] ) ) {
-							$date_query        = $block_query['date_query'];
-							$date_relationship = $date_query['relation'];
-							$date_is_inclusive = $date_query['inclusive'];
-							$date_primary      = $date_query['date_primary'];
-							$date_secondary    = ! empty( $date_query['date_secondary'] ) ? $date_query['date_secondary'] : '';
+						$date_query        = $block_query['date_query'] ?? null;
+						$date_relationship = $date_query['relation'] ?? null;
+						$date_primary      = $date_query['date_primary'] ?? null;
+						if ( $date_query && $date_relationship && $date_primary ) {
+							$date_is_inclusive = $date_query['inclusive'] ?? false;
+							$date_secondary    = $date_query['date_secondary'] ?? null;
 
 							// Date format: 2022-12-27T11:14:21.
-							$primary_year    = substr( $date_primary, 0, 4 );
-							$primary_month   = substr( $date_primary, 5, 2 );
-							$primary_day     = substr( $date_primary, 8, 2 );
-							$secondary_year  = substr( $date_secondary, 0, 4 );
-							$secondary_month = substr( $date_secondary, 5, 2 );
-							$secondary_day   = substr( $date_secondary, 8, 2 );
+							$primary_year  = substr( $date_primary, 0, 4 );
+							$primary_month = substr( $date_primary, 5, 2 );
+							$primary_day   = substr( $date_primary, 8, 2 );
 
-							if ( 'between' === $date_relationship ) {
+							if ( 'between' === $date_relationship && $date_secondary ) {
+								$secondary_year  = substr( $date_secondary, 0, 4 );
+								$secondary_month = substr( $date_secondary, 5, 2 );
+								$secondary_day   = substr( $date_secondary, 8, 2 );
+
 								$date_queries = array(
 									'after'  => array(
 										'year'  => $primary_year,
@@ -269,23 +270,24 @@ function add_custom_query_params( $args, $request ) {
 	}
 
 	// Date related.
-	$date_query = $request->get_param( 'date_query' );
+	$date_query        = $request->get_param( 'date_query' );
+	$date_relationship = $date_query['relation'] ?? null;
+	$date_primary      = $date_query['date_primary'] ?? null;
 
-	if ( $date_query ) {
-		$date_relationship = $date_query['relation'];
-		$date_is_inclusive = ( 'true' === $date_query['inclusive'] ) ? true : false;
-		$date_primary      = $date_query['date_primary'];
-		$date_secondary    = ! empty( $date_query['date_secondary'] ) ? $date_query['date_secondary'] : '';
+	if ( $date_query && $date_relationship && $date_primary ) {
+		$date_is_inclusive = 'true' === $date_query['inclusive'] ?? false;
+		$date_secondary    = $date_query['date_secondary'] ?? null;
 
 		// Date format: 2022-12-27T11:14:21.
-		$primary_year    = substr( $date_primary, 0, 4 );
-		$primary_month   = substr( $date_primary, 5, 2 );
-		$primary_day     = substr( $date_primary, 8, 2 );
-		$secondary_year  = substr( $date_secondary, 0, 4 );
-		$secondary_month = substr( $date_secondary, 5, 2 );
-		$secondary_day   = substr( $date_secondary, 8, 2 );
+		$primary_year  = substr( $date_primary, 0, 4 );
+		$primary_month = substr( $date_primary, 5, 2 );
+		$primary_day   = substr( $date_primary, 8, 2 );
 
-		if ( 'between' === $date_relationship ) {
+		if ( 'between' === $date_relationship && $date_secondary ) {
+			$secondary_year  = substr( $date_secondary, 0, 4 );
+			$secondary_month = substr( $date_secondary, 5, 2 );
+			$secondary_day   = substr( $date_secondary, 8, 2 );
+
 			$date_queries = array(
 				'after'  => array(
 					'year'  => $primary_year,


### PR DESCRIPTION
I noticed on PHP 8 that a lot of errors can occur if a date query is activated, but values are initially not set (i.e. being just empty). These changes should prevent these warnings and errors.