### PR TITLE
Revert "Put global constants in namespace"

### DIFF
--- a/index.php
+++ b/index.php
@@ -19,8 +19,8 @@
 namespace AdvancedQueryLoop;
 
 // Some helpful constants.
-const BUILD_DIR_PATH = plugin_dir_path( __FILE__ ) . 'build/';
-const BUILD_DIR_URL = plugin_dir_url( __FILE__ ) . 'build/';
+define( 'BUILD_DIR_PATH', plugin_dir_path( __FILE__ ) . 'build/' );
+define( 'BUILD_DIR_URL', plugin_dir_url( __FILE__ ) . 'build/' );
 
 // Require some files.
 require_once __DIR__ . '/includes/enqueues.php';


### PR DESCRIPTION
Reverts the PR. Definine constants like this triggers a fatal error