### PR TITLE
Fix: Inherited query gets an empty `s` param.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ DNU
 /vendor/
 composer.lock
 .phpunit.*
+artifacts

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,9 @@
+{
+	"core": "WordPress/WordPress",
+	"plugins": [ "." ],
+	"env": {
+		"tests": {
+			"phpVersion": "8.1"
+		}
+	}
+}

--- a/includes/query-loop.php
+++ b/includes/query-loop.php
@@ -49,7 +49,7 @@ function get_exclude_ids( $attributes ) {
 
 	// Exclude Current Post.
 	if ( isset( $attributes['exclude_current'] ) && boolval( $attributes['exclude_current'] ) ) {
-		array_push( $exclude_ids, $attributes['exclude_current']);
+		array_push( $exclude_ids, $attributes['exclude_current'] );
 	}
 
 	return $exclude_ids;
@@ -101,14 +101,12 @@ function get_exclude_ids( $attributes ) {
 			} else {
 				\add_filter(
 					'query_loop_block_query_vars',
-					function( $default_query ) use ( $parsed_block ) {
-						$block_query = $parsed_block['attrs']['query'];
+					function( $default_query, $block ) {
+						// Retrieve the query from the passed block context.
+						$block_query = $block->context['query'];
+
 						// Generate a new custom query will all potential query vars.
 						$query_args = array();
-
-						if ( count( $query_args ) )  {
-							die( var_dump( $parsed_block['attrs']['query'] , $query_args)  );
-						}
 
 						// Post Related.
 						if ( isset( $block_query['multiple_posts'] ) && ! empty( $block_query['multiple_posts'] ) ) {
@@ -117,7 +115,7 @@ function get_exclude_ids( $attributes ) {
 
 						// Exclude Posts.
 						$exclude_ids = get_exclude_ids( $block_query );
-						if (  ! empty( $exclude_ids ) ) {
+						if ( ! empty( $exclude_ids ) ) {
 							$query_args['post__not_in'] = $exclude_ids;
 						}
 

--- a/includes/query-loop.php
+++ b/includes/query-loop.php
@@ -106,6 +106,10 @@ function get_exclude_ids( $attributes ) {
 						// Generate a new custom query will all potential query vars.
 						$query_args = array();
 
+						if ( count( $query_args ) )  {
+							die( var_dump( $parsed_block['attrs']['query'] , $query_args)  );
+						}
+
 						// Post Related.
 						if ( isset( $block_query['multiple_posts'] ) && ! empty( $block_query['multiple_posts'] ) ) {
 							$query_args['post_type'] = array_merge( array( $default_query['post_type'] ), $block_query['multiple_posts'] );
@@ -118,6 +122,8 @@ function get_exclude_ids( $attributes ) {
 						}
 
 						// Check for meta queries.
+						// Ensure any old meta is removed @see https://github.com/ryanwelcher/advanced-query-loop/issues/29
+						$query_args['meta_query'] = array();
 						if ( isset( $block_query['meta_query'] ) && ! empty( $block_query['meta_query'] ) ) {
 							$query_args['meta_query'] = parse_meta_query( $block_query['meta_query'] ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 						}

--- a/includes/query-loop.php
+++ b/includes/query-loop.php
@@ -7,6 +7,8 @@
 
 namespace AdvancedQueryLoop;
 
+use function AdvancedQueryLoop\Taxonomy\parse_taxonomy_query;
+
 /**
  * Adds the custom query attributes to the Query Loop block.
  *
@@ -38,7 +40,7 @@ function parse_meta_query( $meta_query_data ) {
 
 /**
  * Returns an array with Post IDs that should be excluded from the Query.
- * 
+ *
  * @param array
  * @return array
  */
@@ -227,6 +229,7 @@ function add_more_sort_by( $query_params, $post_type ) {
 	$query_params['orderby']['enum'][] = 'meta_value';
 	$query_params['orderby']['enum'][] = 'meta_value_num';
 	$query_params['orderby']['enum'][] = 'rand';
+	// die( '<pre>' .print_r( $query_params , 1 ) .'</pre>' );
 	return $query_params;
 }
 
@@ -239,6 +242,12 @@ function add_more_sort_by( $query_params, $post_type ) {
 function add_custom_query_params( $args, $request ) {
 	// Generate a new custom query will all potential query vars.
 	$custom_args = array();
+
+	// Taxonomy Related
+	$tax_query = $request->get_param( 'tax_query' );
+	if ( $tax_query ) {
+		$custom_args['tax_query'] = parse_taxonomy_query( $tax_query );
+	}
 
 	// Post Related.
 	$multiple_post_types = $request->get_param( 'multiple_posts' );
@@ -313,10 +322,13 @@ function add_custom_query_params( $args, $request ) {
 		$request->get_params(),
 		false,
 	);
-
 	// Merge all queries.
-	return array_merge(
+	$merged = array_merge(
 		$args,
 		array_filter( $filtered_query_args )
 	);
+
+	// die( var_dump( $request->get_params() ) );
+
+	return $merged;
 }

--- a/includes/taxonomy.php
+++ b/includes/taxonomy.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Taxonomy relation functions
+ *
+ * @package AdvancedQueryLoop\Taxonomy
+ */
+
+namespace AdvancedQueryLoop\Taxonomy;
+
+function convert_names_to_ids( $names, $tax ) {
+	$rtn = [];
+	foreach ( $names as $name ) {
+		$term = get_term_by( 'name', $name, $tax );
+		if ( $term ) {
+			$rtn[] = $term->term_id;
+		}
+	}
+	return $rtn;
+}
+
+function parse_taxonomy_query( $tax_query_data ) {
+	return [
+		[
+			'taxonomy'         => $tax_query_data['taxonomy'],
+			'terms'            => convert_names_to_ids( $tax_query_data['terms'], $tax_query_data['taxonomy'] ),
+			'include_children' => ( ! isset( $tax_query_data['include_children'] ) || 'true' === $tax_query_data['include_children'] ) ? true : false,
+			'operator'         => $tax_query_data['operator'],
+		],
+	];
+}

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Advanced Query Loop
  * Description:       Query loop block variations to create custom queries.
  * Plugin URI:        https://github.com/ryanwelcher/advanced-query-loop/
- * Version:           2.0.0
+ * Version:           2.1.0
  * Requires at least: 6.1
  * Requires PHP:      7.2
  * Author:            Ryan Welcher

--- a/index.php
+++ b/index.php
@@ -19,8 +19,8 @@
 namespace AdvancedQueryLoop;
 
 // Some helpful constants.
-define( 'BUILD_DIR_PATH', plugin_dir_path( __FILE__ ) . 'build/' );
-define( 'BUILD_DIR_URL', plugin_dir_url( __FILE__ ) . 'build/' );
+const BUILD_DIR_PATH = plugin_dir_path( __FILE__ ) . 'build/';
+const BUILD_DIR_URL = plugin_dir_url( __FILE__ ) . 'build/';
 
 // Require some files.
 require_once __DIR__ . '/includes/enqueues.php';

--- a/index.php
+++ b/index.php
@@ -19,8 +19,8 @@
 namespace AdvancedQueryLoop;
 
 // Some helpful constants.
-const BUILD_DIR_PATH = plugin_dir_path( __FILE__ ) . 'build/';
-const BUILD_DIR_URL = plugin_dir_url( __FILE__ ) . 'build/';
+define( 'BUILD_DIR_PATH', plugin_dir_path( __FILE__ ) . 'build/' );
+define( 'BUILD_DIR_URL', plugin_dir_url( __FILE__ ) . 'build/' );
 
 // Require some files.
 require_once __DIR__ . '/includes/enqueues.php';

--- a/index.php
+++ b/index.php
@@ -25,3 +25,4 @@ define( 'BUILD_DIR_URL', plugin_dir_url( __FILE__ ) . 'build/' );
 // Require some files.
 require_once __DIR__ . '/includes/enqueues.php';
 require_once __DIR__ . '/includes/query-loop.php';
+require_once __DIR__ . '/includes/taxonomy.php';

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Advanced Query Loop
  * Description:       Query loop block variations to create custom queries.
  * Plugin URI:        https://github.com/ryanwelcher/advanced-query-loop/
- * Version:           2.1.0
+ * Version:           2.1.1
  * Requires at least: 6.1
  * Requires PHP:      7.2
  * Author:            Ryan Welcher

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "advanced-query-loop",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"description": "",
 	"main": "index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "advanced-query-loop",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"description": "",
 	"main": "index.js",
 	"scripts": {

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,7 @@ Sort in ascending or descending order by:
 -   Meta Value Num
 -   Random
 -   Menu Order ( props to @jvanja )
+-   Post ID ( props to @markhowellsmead )
 
 **Please note that this is a slight duplication of the existing sorting controls. They both work interchangeably but it just looks a bit odd in the UI**
 

--- a/readme.txt
+++ b/readme.txt
@@ -55,7 +55,7 @@ Sort in ascending or descending order by:
 3. Query posts before a date, after a date or between two dates.
 
 == Changelog ==
-= 2.0.0 =
+= 2.1.0 =
 * ACF custom fields now show in the auto-complete dropdown list for Post Meta Queries ( props to @jvanja  )
 * Adds sort by Post ID ( props to @markhowellsmead )
 * Fixes a typo in the Order By label.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: welcher
 Tags: Query Loop, Custom Queries
 Requires at least: 6.2
 Tested up to: 6.4
-Stable tag: 2.1.0
+Stable tag: 2.1.1
 Requires PHP: 7.2
 License: GPL v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -55,6 +55,9 @@ Sort in ascending or descending order by:
 3. Query posts before a date, after a date or between two dates.
 
 == Changelog ==
+= 2.1.1 =
+* Fixes issue with multiple AQL instances having settings leaked to each other.
+
 = 2.1.0 =
 * ACF custom fields now show in the auto-complete dropdown list for Post Meta Queries ( props to @jvanja  )
 * Adds sort by Post ID ( props to @markhowellsmead )

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: welcher
 Tags: Query Loop, Custom Queries
 Requires at least: 6.2
 Tested up to: 6.4
-Stable tag: 2.0.0
+Stable tag: 2.1.0
 Requires PHP: 7.2
 License: GPL v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -44,6 +44,7 @@ Sort in ascending or descending order by:
 -   Meta Value Num
 -   Random
 -   Menu Order ( props to @jvanja )
+-   Post ID ( props to @markhowellsmead )
 
 **Please note that this is a slight duplication of the existing sorting controls. They both work interchangeably but it just looks a bit odd in the UI**
 
@@ -54,6 +55,12 @@ Sort in ascending or descending order by:
 3. Query posts before a date, after a date or between two dates.
 
 == Changelog ==
+= 2.0.0 =
+* ACF custom fields now show in the auto-complete dropdown list for Post Meta Queries ( props to @jvanja  )
+* Adds sort by Post ID ( props to @markhowellsmead )
+* Fixes a typo in the Order By label.
+* Fixes a bug where a second AQL instances was getting post meta query values from the first.
+
 = 2.0.0 =
 * Due to a change in core, Post Count can no longer be overridden when the block is set to inherit the query.
 * Adds Exclude current post option. Props to @Pulsar-X

--- a/src/components/post-meta-query-controls.js
+++ b/src/components/post-meta-query-controls.js
@@ -31,7 +31,7 @@ export const PostMetaQueryControls = ( { attributes, setAttributes } ) => {
 
 	const [ selectedPostType ] = useState( postType );
 
-	const registeredMeta = records?.[ 0 ]?.meta || {};
+	const registeredMeta = records?.[ 0 ]?.meta || records?.[ 0 ]?.acf || {};
 
 	useEffect( () => {
 		// If the post type changes, reset the meta query.

--- a/src/components/post-meta-query-controls.js
+++ b/src/components/post-meta-query-controls.js
@@ -16,6 +16,19 @@ import { useEffect, useState } from '@wordpress/element';
  */
 import { PostMetaControl } from './post-meta-control';
 
+/**
+ * Converts the meta keys from the all sources into a single array.
+ *
+ * @param {Array} records
+ * @return {Array} meta keys
+ */
+const combineMetaKeys = ( records ) => {
+	return {
+		...records?.[ 0 ]?.meta,
+		...records?.[ 0 ]?.acf,
+	};
+};
+
 // A component to render a select control for the post meta query.
 export const PostMetaQueryControls = ( { attributes, setAttributes } ) => {
 	const {
@@ -31,7 +44,7 @@ export const PostMetaQueryControls = ( { attributes, setAttributes } ) => {
 
 	const [ selectedPostType ] = useState( postType );
 
-	const registeredMeta = records?.[ 0 ]?.meta || records?.[ 0 ]?.acf || {};
+	const registeredMeta = combineMetaKeys( records );
 
 	useEffect( () => {
 		// If the post type changes, reset the meta query.

--- a/src/components/post-order-controls.js
+++ b/src/components/post-order-controls.js
@@ -15,7 +15,7 @@ export const PostOrderControls = ( { attributes, setAttributes } ) => {
 	return (
 		<>
 			<SelectControl
-				label={ __( 'Post Order Order By', 'advanced-query-loop' ) }
+				label={ __( 'Post Order By', 'advanced-query-loop' ) }
 				value={ orderBy }
 				help={
 					orderBy === 'meta_value' || orderBy === 'meta_value_num'
@@ -60,6 +60,10 @@ export const PostOrderControls = ( { attributes, setAttributes } ) => {
 					{
 						label: __( 'Menu Order', 'advanced-query-loop' ),
 						value: 'menu_order',
+					},
+					{
+						label: __( 'Post ID', 'advanced-query-loop' ),
+						value: 'id',
 					},
 				] }
 				onChange={ ( newOrderBy ) => {

--- a/src/components/taxonomy-select.js
+++ b/src/components/taxonomy-select.js
@@ -1,0 +1,166 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	FormTokenField,
+	SelectControl,
+	ToggleControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
+import { useState, useMemo, useEffect } from '@wordpress/element';
+import { useDebounce } from '@wordpress/compose';
+
+const operatorOptions = [ 'IN', 'NOT IN', 'EXISTS', 'NOT EXISTS', 'AND' ];
+
+export const TaxonomySelect = ( { attributes, setAttributes } ) => {
+	const { query: { postType, tax_query: taxQuery = {} } = {} } = attributes;
+	const {
+		taxonomy = '',
+		terms = [],
+		operator,
+		include_children: includeChildren = true,
+	} = taxQuery;
+
+	const [ searchTerm, setSearchTerm ] = useState( '' );
+	const [ isHierarchical, setIsHierarchical ] = useState( false );
+	const debouncedSetSearchTerm = useDebounce( setSearchTerm, 500 );
+
+	// When there is only 1 term, we need to use the IN operator.
+	useEffect( () => {
+		if ( taxonomy && terms.length < 2 && operator !== 'IN' ) {
+			setAttributes( {
+				query: {
+					...attributes.query,
+					tax_query: {
+						...attributes.query.tax_query,
+						operator: 'IN',
+					},
+				},
+			} );
+		}
+	}, [ attributes, terms, setAttributes, operator, taxonomy ] );
+
+	useEffect( () => {
+		if ( ! taxonomy ) {
+			setAttributes( {
+				query: {
+					...attributes.query,
+					tax_query: {},
+				},
+			} );
+		}
+	}, [ taxonomy, setAttributes ] );
+
+	const taxonomies = useSelect( ( select ) =>
+		select( coreStore )
+			.getTaxonomies()
+			.filter( ( { types } ) => types.includes( postType ) )
+	);
+
+	const { records } = useEntityRecords( 'taxonomy', taxonomy, {
+		per_page: 10,
+		search: searchTerm,
+		_fields: 'id,name',
+		context: 'view',
+	} );
+
+	const suggestions = useMemo( () => {
+		return ( records ?? [] ).map( ( term ) => term.name );
+	}, [ records ] );
+
+	return (
+		<>
+			<h2>{ __( 'Taxonomy Query', 'advanced-query-loop' ) }</h2>
+			<SelectControl
+				label={ __( 'Taxonomy', 'advanced-query-loop' ) }
+				value={ taxQuery?.taxonomy }
+				options={ [
+					{ label: 'Choose taxonomy', value: '' },
+					...taxonomies.map( ( { name, slug } ) => {
+						return { label: name, value: slug };
+					} ),
+				] }
+				onChange={ ( newTaxonomy ) => {
+					setAttributes( {
+						query: {
+							...attributes.query,
+							tax_query: {
+								...attributes.query.taxQuery,
+								taxonomy: newTaxonomy,
+							},
+						},
+					} );
+				} }
+			/>
+			{ taxonomy.length > 1 && (
+				<>
+					<FormTokenField
+						label={ __( 'Term(s)', 'advanced-query-loop' ) }
+						suggestions={ suggestions }
+						value={ terms }
+						onInputChange={ ( newInput ) => {
+							debouncedSetSearchTerm( newInput );
+						} }
+						onChange={ ( newTerms ) => {
+							setAttributes( {
+								query: {
+									...attributes.query,
+									tax_query: {
+										...attributes.query.tax_query,
+										terms: newTerms,
+									},
+								},
+							} );
+						} }
+					/>
+					<ToggleControl
+						label={ __(
+							'Include children?',
+							'advanced-query-loop'
+						) }
+						checked={ includeChildren }
+						onChange={ () => {
+							setAttributes( {
+								query: {
+									...attributes.query,
+									tax_query: {
+										...attributes.query.tax_query,
+										include_children: ! includeChildren,
+									},
+								},
+							} );
+						} }
+						help={ __(
+							'For hierarchical taxonomies only',
+							'advanced-query-loop'
+						) }
+						disabled={ ! isHierarchical }
+					/>
+					<SelectControl
+						label={ __( 'Operator', 'advanced-query-loop' ) }
+						value={ operator }
+						options={ [
+							...operatorOptions.map( ( value ) => {
+								return { label: value, value };
+							} ),
+						] }
+						disabled={ terms.length < 2 }
+						onChange={ ( newOperator ) => {
+							setAttributes( {
+								query: {
+									...attributes.query,
+									tax_query: {
+										...attributes.query.tax_query,
+										operator: newOperator,
+									},
+								},
+							} );
+						} }
+					/>
+				</>
+			) }
+		</>
+	);
+};

--- a/src/variations/controls.js
+++ b/src/variations/controls.js
@@ -18,6 +18,7 @@ import { PostDateQueryControls } from '../components/post-date-query-controls';
 import { MultiplePostSelect } from '../components/multiple-post-select';
 import { PostOrderControls } from '../components/post-order-controls';
 import { PostExcludeControls } from '../components/post-exclude-controls';
+import { TaxonomySelect } from '../components/taxonomy-select';
 
 /**
  * Determines if the active variation is this one
@@ -54,6 +55,7 @@ const withAdvancedQueryControls = ( BlockEdit ) => ( props ) => {
 								'advanced-query-loop'
 							) }
 						>
+							<TaxonomySelect { ...props } />
 							<MultiplePostSelect { ...props } />
 							<PostCountControls { ...props } />
 							<PostOffsetControls { ...props } />


### PR DESCRIPTION
This PR fixes empty `s` params causing `is_seach()` to be triggered with Inherit Query is checked.

Closes #48.