### PR TITLE
Remove useState hook for the excluded current post that was causing Maximum update depth exceeded errors.

### DIFF
--- a/src/components/post-include-controls.js
+++ b/src/components/post-include-controls.js
@@ -24,8 +24,6 @@ export const PostIncludeControls = ( { attributes, setAttributes } ) => {
 	const [ searchArg, setSearchArg ] = useState( '' );
 	const [ multiplePostsState, setMultiplePostsState ] =
 		useState( multiplePosts );
-	const [ excludeCurrentState, setExcludeCurrentState ] =
-		useState( excludeCurrent );
 
 	const posts = useSelect(
 		( select ) => {
@@ -58,8 +56,7 @@ export const PostIncludeControls = ( { attributes, setAttributes } ) => {
 	useEffect( () => {
 		if (
 			JSON.stringify( multiplePosts ) !==
-				JSON.stringify( multiplePostsState ) ||
-			excludeCurrent !== excludeCurrentState
+			JSON.stringify( multiplePostsState )
 		) {
 			setAttributes( {
 				query: {
@@ -68,10 +65,9 @@ export const PostIncludeControls = ( { attributes, setAttributes } ) => {
 				},
 			} );
 			setMultiplePostsState( multiplePosts );
-			setExcludeCurrentState( excludeCurrent );
 		}
-	}, [ multiplePosts, excludeCurrent ] );
-	
+	}, [ multiplePosts ] );
+
 	/**
 	 * Retrieves the ID of a post based on its title.
 	 *


### PR DESCRIPTION
This PR fixes an issue that was introduced with #40 where a useState hook causing the block to crash in certain cases. The variable created for the state was not being used other than to set the state so I have removed it.

CC @jenniferfarhat, just wanted to be sure that I didn't miss anything with this PR