### PR TITLE
Add "AQL" and "aql" shortcuts to quickly insert new instance of AQL

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -7,10 +7,8 @@ template: |
 
 categories:
     - title: '🚀 Features'
-      collapse-after: 3
       label: 'enhancement'
     - title: '🐛 Bug Fixes'
-      collapse-after: 3
       labels:
           - 'fix'
           - 'bugfix'

--- a/src/variations/controls.js
+++ b/src/variations/controls.js
@@ -113,6 +113,7 @@ function addAQLTransforms( settings, name ) {
 
 	return {
 		...settings,
+		keywords: [ ...settings.keywords, 'AQL', 'aql' ],
 		transforms: {
 			to: settings?.transforms?.to || [],
 			from: [

--- a/src/variations/controls.js
+++ b/src/variations/controls.js
@@ -5,6 +5,7 @@ import { addFilter } from '@wordpress/hooks';
 import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { createBlock } from '@wordpress/blocks';
 /**
  *  Internal dependencies
  */
@@ -92,4 +93,50 @@ const withAdvancedQueryControls = ( BlockEdit ) => ( props ) => {
 	return <BlockEdit { ...props } />;
 };
 
-addFilter( 'editor.BlockEdit', 'core/query', withAdvancedQueryControls );
+addFilter(
+	'editor.BlockEdit',
+	'aql/add-add-controls/core/query',
+	withAdvancedQueryControls
+);
+
+/**
+ * Filter to add AQL transform to core/query block
+ *
+ * @param {Object} settings
+ * @param {string} name
+ * @return {Object} settings
+ */
+function addAQLTransforms( settings, name ) {
+	if ( name !== 'core/query' ) {
+		return settings;
+	}
+
+	return {
+		...settings,
+		transforms: {
+			to: settings?.transforms?.to || [],
+			from: [
+				...( settings?.transforms?.from || [] ),
+				{
+					type: 'enter',
+					regExp: /^(AQL|aql)$/,
+					transform: () => {
+						return createBlock(
+							'core/query',
+							{
+								namespace: 'advanced-query-loop',
+							},
+							[]
+						);
+					},
+				},
+			],
+		},
+	};
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'aql/add-transforms/query-block',
+	addAQLTransforms
+);


### PR DESCRIPTION
Having a fast way to insert a new instance of AQL is something I've been wanting for a while. This PR add the abilty to type "AQL" or "aql" and hit return in the block editor to quickly insert a new instance.