### PR TITLE
Address fatals due to type hinting.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,9 @@
 		"phpunit/phpunit": "^8.5",
 		"yoast/phpunit-polyfills": "^2.0"
 	},
+	"require": {
+		"php": ">=7.4"
+	},
 	"config": {
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true,

--- a/includes/Query_Params_Generator.php
+++ b/includes/Query_Params_Generator.php
@@ -57,9 +57,9 @@ class Query_Params_Generator {
 	 * @param array $default_params Default values from the default block.
 	 * @param array $custom_params  Custom values from AQL.
 	 */
-	public function __construct( array $default_params, array $custom_params ) {
-		$this->default_params = $default_params;
-		$this->custom_params  = $custom_params;
+	public function __construct( $default_params, $custom_params ) {
+		$this->default_params = is_array( $default_params ) ? $default_params : [];
+		$this->custom_params  = is_array( $custom_params ) ? $custom_params : [];
 	}
 
 	/**
@@ -76,9 +76,11 @@ class Query_Params_Generator {
 	 *
 	 * @param string $name The param to retrieve.
 	 *
+	 * @todo Return mixed type hint for 8.0
+	 *
 	 * @return mixed
 	 */
-	public function get_custom_param( string $name ): mixed {
+	public function get_custom_param( string $name ) {
 		if ( $this->has_custom_param( $name ) ) {
 			return $this->custom_params[ $name ];
 		}

--- a/includes/query-loop.php
+++ b/includes/query-loop.php
@@ -58,7 +58,7 @@ if ( ! function_exists( 'add_filter' ) ) {
 					'query_loop_block_query_vars',
 					function ( $default_query, $block ) {
 						// Retrieve the query from the passed block context.
-						$block_query = $block->context['query'];
+						$block_query = $block->context['query'] ?? [];
 
 						// Process all of the params
 						$qpg = new Query_Params_Generator( $default_query, $block_query );

--- a/tests/unit/Query_Params_Generator_Tests.php
+++ b/tests/unit/Query_Params_Generator_Tests.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Tests for the Query_Params_Generator class functions
+ */
+
+namespace AdvancedQueryLoop\UnitTests;
+
+use AdvancedQueryLoop\Query_Params_Generator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test the generator class
+ */
+class Query_Params_Generator_Tests extends TestCase {
+
+	/**
+	 * Data provider for the empty array tests
+	 *
+	 * @return array
+	 */
+	public function data_empty_null_passed_constructor() {
+		return array(
+			array(
+				null,
+				null,
+			),
+			array(
+				array(),
+				null,
+			),
+			array(
+				null,
+				array(),
+			),
+			array(
+				array(),
+				array(),
+			),
+		);
+	}
+
+	/**
+	 * All of these tests will return empty arrays
+	 *
+	 * @param null|array $default_data The params coming from the default block.
+	 * @param null|array $custom_data  The params coming from AQL.
+	 *
+	 * @dataProvider data_empty_null_passed_constructor
+	 */
+	public function test_empty_null_passed_constructor( $default_data, $custom_data ) {
+
+		$qpg = new Query_Params_Generator( $default_data, $custom_data, );
+		$qpg->process_all();
+
+		// Empty arrays return empty.
+		$this->assertEmpty( $qpg->get_query_args() );
+	}
+}


### PR DESCRIPTION
There have been some issues reported where type hinting has caused fatal errors. This PR addresses those.

Closes: #67

Related support forum issuesL:
* https://wordpress.org/support/topic/facetwp-filters-dont-work-with-query-loop-anymore/
* https://wordpress.org/support/topic/critical-error-when-upgrading-to-3-0-0/
