### PR TITLE
Add control for dynamic date ranges for date queries

### DIFF
--- a/includes/Traits/Date_Query.php
+++ b/includes/Traits/Date_Query.php
@@ -14,50 +14,90 @@ trait Date_Query {
 	 * Main processing function.
 	 */
 	public function process_date_query(): void {
+		// Retrieve the date_query param from the block
+		$date_query = $this->custom_params['date_query'] ?? null;
 
-		$date_query        = $this->custom_params['date_query'] ?? null;
-		$date_relationship = $date_query['relation'] ?? null;
-		$date_primary      = $date_query['date_primary'] ?? null;
-		if ( $date_query && $date_relationship && $date_primary ) {
-			$date_is_inclusive = $date_query['inclusive'] ?? false;
-			$date_secondary    = $date_query['date_secondary'] ?? null;
+		// Ranges and Relationships can't co-exist.
+		$range = $date_query['range'] ?? false;
+		if ( $date_query && $range && ! empty( $range ) ) {
+			$date_queries = $this->process_date_range( $range );
 
-			// Date format: 2022-12-27T11:14:21.
-			$primary_year  = substr( $date_primary, 0, 4 );
-			$primary_month = substr( $date_primary, 5, 2 );
-			$primary_day   = substr( $date_primary, 8, 2 );
+		} else {
+			$date_relationship = $date_query['relation'] ?? null;
+			$date_primary      = $date_query['date_primary'] ?? null;
+			if ( $date_query && $date_relationship && $date_primary ) {
+				$date_is_inclusive = $date_query['inclusive'] ?? false;
+				$date_secondary    = $date_query['date_secondary'] ?? null;
 
-			if ( 'between' === $date_relationship && $date_secondary ) {
-				$secondary_year  = substr( $date_secondary, 0, 4 );
-				$secondary_month = substr( $date_secondary, 5, 2 );
-				$secondary_day   = substr( $date_secondary, 8, 2 );
+				// Date format: 2022-12-27T11:14:21.
+				$primary_year  = substr( $date_primary, 0, 4 );
+				$primary_month = substr( $date_primary, 5, 2 );
+				$primary_day   = substr( $date_primary, 8, 2 );
 
-				$date_queries = array(
-					'after'  => array(
-						'year'  => $primary_year,
-						'month' => $primary_month,
-						'day'   => $primary_day,
-					),
-					'before' => array(
-						'year'  => $secondary_year,
-						'month' => $secondary_month,
-						'day'   => $secondary_day,
-					),
-				);
-			} else {
-				$date_queries = array(
-					$date_relationship => array(
-						'year'  => $primary_year,
-						'month' => $primary_month,
-						'day'   => $primary_day,
-					),
-				);
+				if ( 'between' === $date_relationship && $date_secondary ) {
+					$secondary_year  = substr( $date_secondary, 0, 4 );
+					$secondary_month = substr( $date_secondary, 5, 2 );
+					$secondary_day   = substr( $date_secondary, 8, 2 );
+
+					$date_queries = array(
+						'after'  => array(
+							'year'  => $primary_year,
+							'month' => $primary_month,
+							'day'   => $primary_day,
+						),
+						'before' => array(
+							'year'  => $secondary_year,
+							'month' => $secondary_month,
+							'day'   => $secondary_day,
+						),
+					);
+				} else {
+					$date_queries = array(
+						$date_relationship => array(
+							'year'  => $primary_year,
+							'month' => $primary_month,
+							'day'   => $primary_day,
+						),
+					);
+				}
+				$date_queries['inclusive'] = $date_is_inclusive;
 			}
+		}
 
-			$date_queries['inclusive'] = $date_is_inclusive;
+		// Return the date queries.
+		$this->custom_args['date_query'] = array_filter( $date_queries );
+	}
 
-			// Add the date queries to the custom query.
-			$this->custom_args['date_query'] = array_filter( $date_queries );
+	/**
+	 * Generate the date ranges data
+	 *
+	 * @param string $range The range as provided by the UI.
+	 */
+	public function process_date_range( string $range ) {
+
+		switch ( $range ) {
+			case 'last-month':
+				return array(
+					'before' => 'today',
+					'after'  => 'first day of -1 months',
+				);
+			case 'three-months':
+				return array(
+					'before' => 'today',
+					'after'  => 'first day of -3 months',
+				);
+
+			case 'six-months':
+				return array(
+					'before' => 'today',
+					'after'  => 'first day of -6 months',
+				);
+
+			case 'twelve-months':
+				return array(
+					'before' => 'today',
+					'after'  => 'first day of -12 months',
+				);
 		}
 	}
 }

--- a/src/components/post-date-query-controls.js
+++ b/src/components/post-date-query-controls.js
@@ -16,6 +16,7 @@ export const PostDateQueryControls = ( { attributes, setAttributes } ) => {
 				date_primary: datePrimary = new Date(),
 				date_secondary: dateSecondary = new Date(),
 				inclusive: isInclusive = false,
+				range = '',
 			} = {},
 		} = {},
 	} = attributes;
@@ -24,13 +25,69 @@ export const PostDateQueryControls = ( { attributes, setAttributes } ) => {
 		<>
 			<h2>{ __( 'Post Date Query', 'advanced-query-loop' ) }</h2>
 			<SelectControl
-				label={ __( 'Date Relationship', 'advanced-query-loop' ) }
-				value={ relationFromQuery }
+				label={ __( 'Dynamic Range', 'advanced-query-loop' ) }
+				help={ __(
+					'Show posts from the last month, 3 months, 6 months, or 12 months. Posts are shown from the 1st of the month.',
+					'advanced-query-loop'
+				) }
+				value={ range }
+				disabled={ relationFromQuery !== '' }
 				options={ [
-					{ label: 'None', value: '' },
-					{ label: 'Before', value: 'before' },
-					{ label: 'After', value: 'after' },
-					{ label: 'Between', value: 'between' },
+					{
+						label: __( 'None', 'advanced-query-loop' ),
+						value: '',
+					},
+					{
+						label: __( 'Last month', 'advanced-query-loop' ),
+						value: 'last-month',
+					},
+					{
+						label: __( 'Last 3 months', 'advanced-query-loop' ),
+						value: 'three-months',
+					},
+					{
+						label: __( 'Last 6 months', 'advanced-query-loop' ),
+						value: 'six-months',
+					},
+					{
+						label: __( 'Last 12 months', 'advanced-query-loop' ),
+						value: 'twelve-months',
+					},
+				] }
+				onChange={ ( newRange ) => {
+					setAttributes( {
+						query: {
+							...attributes.query,
+							date_query: {
+								...attributes.query.date_query,
+								range: newRange,
+							},
+						},
+					} );
+				} }
+			/>
+			<SelectControl
+				label={ __( 'Date Relationship', 'advanced-query-loop' ) }
+				help={ __(
+					'Show posts before, after, or between the selected date(s).',
+					'advanced-query-loop'
+				) }
+				value={ relationFromQuery }
+				disabled={ range !== '' }
+				options={ [
+					{ label: __( 'None', 'advanced-query-loop' ), value: '' },
+					{
+						label: __( 'Before', 'advanced-query-loop' ),
+						value: 'before',
+					},
+					{
+						label: __( 'After', 'advanced-query-loop' ),
+						value: 'after',
+					},
+					{
+						label: __( 'Between', 'advanced-query-loop' ),
+						value: 'between',
+					},
 				] }
 				onChange={ ( relation ) => {
 					setAttributes( {

--- a/tests/unit/Date_Query_Tests.php
+++ b/tests/unit/Date_Query_Tests.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Tests for the Date_Query Trait
+ */
+
+namespace AdvancedQueryLoop\UnitTests;
+
+use AdvancedQueryLoop\Query_Params_Generator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Define the test class
+ */
+class Date_Query_Tests extends TestCase {
+
+	public function data_range_and_relationship_are_discreet() {
+		return [
+			[
+				// Range takes precedence
+				[
+					'date_query' => [
+						'range'        => 'last-month',
+						'relation'     => 'before',
+						'date_primary' => '2024-06-05T13:31:35',
+					],
+				],
+				[
+					'date_query' => [
+						'before' => 'today',
+						'after'  => 'first day of -1 months',
+					],
+				],
+			],
+			[
+				// Empty range is ignored
+				[
+					'date_query' => [
+						'range'        => '',
+						'relation'     => 'before',
+						'date_primary' => '2024-06-05T13:31:35',
+					],
+				],
+				[
+					'date_query' => [
+						'before' => [
+							'year'  => '2024',
+							'month' => '06',
+							'day'   => '05',
+						],
+					],
+				],
+			],
+			[
+				// Null range is ignored
+				[
+					'date_query' => [
+						'range'        => null,
+						'relation'     => 'before',
+						'date_primary' => '2024-06-05T13:31:35',
+					],
+				],
+				[
+					'date_query' => [
+						'before' => [
+							'year'  => '2024',
+							'month' => '06',
+							'day'   => '05',
+						],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Ranges and Relationships can't co-exist in they query
+	 *
+	 * @param array $custom_data      The data from the block.
+	 * @param array $expected_results The expected results to test against.
+	 *
+	 * @dataProvider data_range_and_relationship_are_discreet
+	 */
+	public function test_range_and_relationship_are_discreet( $custom_data, $expected_results ) {
+		$qpg = new Query_Params_Generator( [], $custom_data );
+		$qpg->process_all();
+
+		// Empty arrays return empty.
+		$this->assertSame( $expected_results, $qpg->get_query_args() );
+	}
+
+	/**
+	 * Data provider
+	 */
+	public function data_all_ranges_return_expected() {
+		return [
+			// Month
+			[
+				[
+					'date_query' => [
+						'range' => 'last-month',
+					],
+				],
+				[
+					'date_query' => [
+						'before' => 'today',
+						'after'  => 'first day of -1 months',
+					],
+				],
+			],
+			[
+				[
+					'date_query' => [
+						'range' => 'three-months',
+					],
+				],
+				[
+					'date_query' => [
+						'before' => 'today',
+						'after'  => 'first day of -3 months',
+					],
+				],
+			],
+			[
+				[
+					'date_query' => [
+						'range' => 'six-months',
+					],
+				],
+				[
+					'date_query' => [
+						'before' => 'today',
+						'after'  => 'first day of -6 months',
+					],
+				],
+			],
+			[
+				[
+					'date_query' => [
+						'range' => 'twelve-months',
+					],
+				],
+				[
+					'date_query' => [
+						'before' => 'today',
+						'after'  => 'first day of -12 months',
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Ensure range return the expected array
+	 *
+	 * @param array $custom_data      The data from the block.
+	 * @param array $expected_results The expected results to test against.
+	 *
+	 * @dataProvider data_all_ranges_return_expected
+	 */
+	public function test_all_ranges_return_expected( $custom_data, $expected_results ) {
+		$qpg = new Query_Params_Generator( [], $custom_data );
+		$qpg->process_all();
+
+		// Empty arrays return empty.
+		$this->assertSame( $expected_results, $qpg->get_query_args() );
+
+	}
+}


### PR DESCRIPTION
This PR adds a new control to be able to create date queries for the last month, 3 months, 6 months and 12 months.

This has been requested a few times on the the support forum.

* https://wordpress.org/support/topic/current-month-2/
* https://wordpress.org/support/topic/post-sorting-4/