### PR TITLE
Adds control to exclude categories

### DIFF
--- a/includes/Query_Params_Generator.php
+++ b/includes/Query_Params_Generator.php
@@ -17,6 +17,7 @@ class Query_Params_Generator {
 	use Traits\Include_Posts;
 	use Traits\Meta_Query;
 	use Traits\Date_Query;
+	use Traits\Exclude_Taxonomies;
 
 
 	/**
@@ -28,6 +29,7 @@ class Query_Params_Generator {
 		'include_posts',
 		'meta_query',
 		'date_query',
+		'exclude_taxonomies'
 	);
 
 	/**

--- a/includes/Traits/Exclude_Taxonomies.php
+++ b/includes/Traits/Exclude_Taxonomies.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Exclude_Taxonomies
+ */
+
+namespace AdvancedQueryLoop\Traits;
+
+/**
+ * Trait
+ */
+trait Exclude_Taxonomies {
+
+	/**
+	 * Main processing function.
+	 */
+	public function process_exclude_taxonomies(): void {
+		$taxonomies_to_exclude = $this->custom_params['exclude_taxonomies'];
+		if( count( $taxonomies_to_exclude ) ) {
+			$tax_query = [];
+			foreach ( $taxonomies_to_exclude as $slug ) {
+				$tax_query[]  = [
+					'taxonomy' => $slug,
+					'operator' => 'NOT EXISTS'
+				];
+			}
+			$this->custom_args['tax_query'] = $tax_query;
+		}
+	}
+}
+

--- a/src/components/exclude-taxonomies.js
+++ b/src/components/exclude-taxonomies.js
@@ -1,0 +1,93 @@
+/**
+ * WordPress dependencies
+ */
+/**
+ * WordPress dependencies
+ */
+import { FormTokenField, BaseControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as coreDataStore } from '@wordpress/core-data';
+
+/**
+ * A helper to retrieve the correct items to display or save in the token field
+ *
+ * @param {Array}  subSet
+ * @param {Array}  fullSet
+ * @param {string} lookupProperty
+ * @param {string} returnProperty
+ * @return {Array} The correct items to display or save in the token field
+ */
+function prepDataFromTokenField(
+	subSet,
+	fullSet,
+	lookupProperty,
+	returnProperty
+) {
+	const subsetFullObjects = fullSet.filter( ( item ) =>
+		subSet.includes( item[ lookupProperty ] )
+	);
+	return subsetFullObjects.map(
+		( { [ returnProperty ]: returnVal } ) => returnVal
+	);
+}
+
+export const ExcludeTaxonomies = ( { attributes, setAttributes } ) => {
+	const {
+		query: {
+			multiple_posts: multiplePosts = [],
+			postType,
+			excluded_taxonomies: excludedTaxonomies = [],
+		} = {},
+	} = attributes;
+
+	const taxonomies = useSelect(
+		( select ) => {
+			const knownTaxes = select( coreDataStore ).getTaxonomies();
+			return knownTaxes.filter(
+				( { types } ) =>
+					types.includes( postType ) ||
+					types.some( ( i ) => multiplePosts.includes( i ) )
+			);
+		},
+		[ multiplePosts, postType ]
+	);
+
+	return (
+		<BaseControl
+			help={ __(
+				'Choose taxonomies to exclude from the query.',
+				'advanced-query-loop'
+			) }
+		>
+			<FormTokenField
+				label={ __( 'Exclude Taxonomies', 'advanced-query-loop' ) }
+				value={
+					prepDataFromTokenField(
+						excludedTaxonomies,
+						taxonomies,
+						'slug',
+						'name'
+					) || []
+				}
+				suggestions={ [ ...taxonomies?.map( ( { name } ) => name ) ] }
+				onChange={ ( selectedTaxonomies ) => {
+					setAttributes( {
+						query: {
+							...attributes.query,
+							excluded_taxonomies:
+								prepDataFromTokenField(
+									selectedTaxonomies,
+									taxonomies,
+									'name',
+									'slug'
+								) || [],
+						},
+					} );
+				} }
+				__experimentalExpandOnFocus
+				__experimentalShowHowTo={ false }
+			/>
+		</BaseControl>
+	);
+};

--- a/src/components/exclude-taxonomies.js
+++ b/src/components/exclude-taxonomies.js
@@ -37,7 +37,7 @@ export const ExcludeTaxonomies = ( { attributes, setAttributes } ) => {
 		query: {
 			multiple_posts: multiplePosts = [],
 			postType,
-			excluded_taxonomies: excludedTaxonomies = [],
+			exclude_taxonomies: excludeTaxonomies = [],
 		} = {},
 	} = attributes;
 
@@ -64,7 +64,7 @@ export const ExcludeTaxonomies = ( { attributes, setAttributes } ) => {
 				label={ __( 'Exclude Taxonomies', 'advanced-query-loop' ) }
 				value={
 					prepDataFromTokenField(
-						excludedTaxonomies,
+						excludeTaxonomies,
 						taxonomies,
 						'slug',
 						'name'
@@ -75,7 +75,7 @@ export const ExcludeTaxonomies = ( { attributes, setAttributes } ) => {
 					setAttributes( {
 						query: {
 							...attributes.query,
-							excluded_taxonomies:
+							exclude_taxonomies:
 								prepDataFromTokenField(
 									selectedTaxonomies,
 									taxonomies,

--- a/src/variations/controls.js
+++ b/src/variations/controls.js
@@ -20,6 +20,7 @@ import { MultiplePostSelect } from '../components/multiple-post-select';
 import { PostOrderControls } from '../components/post-order-controls';
 import { PostExcludeControls } from '../components/post-exclude-controls';
 import { PostIncludeControls } from '../components/post-include-controls';
+import { ExcludeTaxonomies } from '../components/exclude-taxonomies';
 
 /**
  * Determines if the active variation is this one
@@ -61,6 +62,7 @@ const withAdvancedQueryControls = ( BlockEdit ) => ( props ) => {
 							<PostOffsetControls { ...props } />
 							<PostOrderControls { ...props } />
 							<PostExcludeControls { ...props } />
+							<ExcludeTaxonomies { ...props } />
 							<PostIncludeControls { ...props } />
 							<PostMetaQueryControls { ...props } />
 							<PostDateQueryControls { ...props } />


### PR DESCRIPTION
The PR introduces a new control to allow users to exclude posts based on taxonomy. It's a really great start and paves the way for adding exclusion based on individual terms. 

Closes #83 