### PR TITLE
Show children of current item only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ DNU
 composer.lock
 .phpunit.*
 artifacts
+.vscode

--- a/includes/Query_Params_Generator.php
+++ b/includes/Query_Params_Generator.php
@@ -19,6 +19,7 @@ class Query_Params_Generator {
 	use Traits\Date_Query;
 	use Traits\Exclude_Taxonomies;
 	use Traits\Disable_Pagination;
+	use Traits\Post_Parent;
 
 
 	/**
@@ -32,6 +33,7 @@ class Query_Params_Generator {
 		'date_query',
 		'exclude_taxonomies',
 		'disable_pagination',
+		'post_parent',
 	);
 
 	/**
@@ -64,6 +66,20 @@ class Query_Params_Generator {
 	public function __construct( $default_params, $custom_params ) {
 		$this->default_params = is_array( $default_params ) ? $default_params : array();
 		$this->custom_params  = is_array( $custom_params ) ? $custom_params : array();
+	}
+
+
+	/**
+	 * Checks to see if the item that is passed is a post ID.
+	 *
+	 * This is used to check if the user is editing a template
+	 *
+	 * @param mixed $possible_post_id The potential post id
+	 *
+	 * @return bool Whether the passed item is a post id or not.
+	 */
+	private function is_post_id( $possible_post_id ) {
+		return is_int( $possible_post_id ) || ! preg_match( '/[a-z\-]+\/\/[a-z\-]+/', $possible_post_id );
 	}
 
 	/**

--- a/includes/Traits/Exclude_Current.php
+++ b/includes/Traits/Exclude_Current.php
@@ -28,7 +28,7 @@ trait Exclude_Current {
 		// If there are already posts to be excluded, we need to add to them.
 		$exclude_ids = $this->custom_args['post__not_in'] ?? array();
 
-		if ( is_int( $to_exclude ) || ! preg_match( '/[a-z\-]+\/\/[a-z\-]+/', $to_exclude ) ) {
+		if ( $this->is_post_id( $to_exclude ) ) {
 			array_push( $exclude_ids, intval( $to_exclude ) );
 		} else {
 			// This is usually when this was set on a template.

--- a/includes/Traits/Post_Parent.php
+++ b/includes/Traits/Post_Parent.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Post Parent Processing
+ */
+
+namespace AdvancedQueryLoop\Traits;
+
+/**
+ * Trait
+ */
+trait Post_Parent {
+
+	/**
+	 * Main processing function.
+	 */
+	public function process_post_parent(): void {
+		$parent = $this->custom_params['post_parent'];
+
+		if ( $this->is_post_id( $parent ) ) {
+			$this->custom_args['post_parent'] = $parent;
+		} else {
+			// This is usually when this was set on a template.
+			global $post;
+			$this->custom_args['post_parent'] = $post->ID;
+		}
+	}
+}

--- a/src/components/child-items-toggle.js
+++ b/src/components/child-items-toggle.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+import { ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { store as editorStore } from '@wordpress/editor';
+
+export const ChildItemsToggle = ( { attributes, setAttributes } ) => {
+	const { query: { post_parent: postParent } = {} } = attributes;
+
+	const { isHierarchial, postTypeName, postID } = useSelect( ( select ) => {
+		const post = select( editorStore ).getCurrentPost();
+		const postType = select( editorStore ).getCurrentPostType();
+		const postTypeObject = select( coreStore ).getPostType( postType );
+
+		return {
+			isHierarchial: postTypeObject?.hierarchical,
+			postTypeName: postType,
+			postID: post?.id,
+		};
+	}, [] );
+
+	return (
+		<ToggleControl
+			__nextHasNoMarginBottom
+			label={ __( 'Show child items only', 'advanced-query-loop' ) }
+			help={ __(
+				'Only show child items of this item. This option is only available for hierarchical post types such as pages.',
+				'advanced-query-loop'
+			) }
+			disabled={ ! isHierarchial && postTypeName !== 'wp_template' }
+			checked={ !! postParent }
+			onChange={ ( value ) =>
+				setAttributes( {
+					query: {
+						...attributes.query,
+						post_parent: value ? postID : 0,
+					},
+				} )
+			}
+		/>
+	);
+};

--- a/src/components/pagination-toggle.js
+++ b/src/components/pagination-toggle.js
@@ -10,6 +10,7 @@ export const PaginationToggle = ( { attributes, setAttributes } ) => {
 
 	return (
 		<ToggleControl
+			__nextHasNoMarginBottom
 			label={ __( 'Disable pagination', 'advanced-query-loop' ) }
 			help={ __(
 				'Disabling pagination will not show any pagination controls on the front end. It can also provide a performance improvement for complicated queries.',

--- a/src/components/post-exclude-controls.js
+++ b/src/components/post-exclude-controls.js
@@ -48,6 +48,7 @@ export const PostExcludeControls = ( { attributes, setAttributes } ) => {
 		<>
 			<h2> { __( 'Exclude Posts', 'advanced-query-loop' ) }</h2>
 			<ToggleControl
+				__nextHasNoMarginBottom
 				label={ __( 'Exclude Current Post', 'advanced-query-loop' ) }
 				checked={ !! excludeCurrent }
 				disabled={ isDisabled() }

--- a/src/components/post-order-controls.js
+++ b/src/components/post-order-controls.js
@@ -89,6 +89,7 @@ export const PostOrderControls = ( { attributes, setAttributes } ) => {
 				} }
 			/>
 			<ToggleControl
+				__nextHasNoMarginBottom
 				label={ __( 'Ascending Order', 'advanced-query-loop' ) }
 				checked={ order === 'asc' }
 				onChange={ () => {

--- a/src/variations/controls.js
+++ b/src/variations/controls.js
@@ -21,6 +21,7 @@ import { PostExcludeControls } from '../components/post-exclude-controls';
 import { PostIncludeControls } from '../components/post-include-controls';
 import { ExcludeTaxonomies } from '../components/exclude-taxonomies';
 import { PaginationToggle } from '../components/pagination-toggle';
+import { ChildItemsToggle } from '../components/child-items-toggle';
 
 /**
  * Determines if the active variation is this one
@@ -66,6 +67,7 @@ const withAdvancedQueryControls = ( BlockEdit ) => ( props ) => {
 							<PostExcludeControls { ...props } />
 							<ExcludeTaxonomies { ...props } />
 							<PostIncludeControls { ...props } />
+							<ChildItemsToggle { ...props } />
 							<PostMetaQueryControls { ...props } />
 							<PostDateQueryControls { ...props } />
 							<AQLControls.Slot fillProps={ { ...props } } />


### PR DESCRIPTION
This feature was request in the [support forum](https://wordpress.org/support/topic/get-children-of-page-in-template/)