### PR TITLE
Remove duplicate props __nextHasNoMarginBottom

### DIFF
--- a/src/components/post-order-controls.js
+++ b/src/components/post-order-controls.js
@@ -90,7 +90,6 @@ export const PostOrderControls = ( { attributes, setAttributes } ) => {
 				__nextHasNoMarginBottom
 			/>
 			<ToggleControl
-				__nextHasNoMarginBottom
 				label={ __( 'Ascending Order', 'advanced-query-loop' ) }
 				checked={ order === 'asc' }
 				onChange={ () => {


### PR DESCRIPTION
Delete duplicate prop `__nextHasNoMarginBottom`.

---

Property `__nextHasNoMarginBottom` declared twice.

https://github.com/ryanwelcher/advanced-query-loop/blob/e6f7fe7468055b2e19e0c96ea22fbe9672559c16/src/components/post-order-controls.js#L93

https://github.com/ryanwelcher/advanced-query-loop/blob/e6f7fe7468055b2e19e0c96ea22fbe9672559c16/src/components/post-order-controls.js#L104