### PR TITLE
Allow extended orderby values for all publicly queryable post types

### DIFF
--- a/includes/query-loop.php
+++ b/includes/query-loop.php
@@ -98,7 +98,7 @@ if ( ! function_exists( 'add_filter' ) ) {
 \add_action(
 	'init',
 	function () {
-		$registered_post_types = \get_post_types( array( 'public' => true ) );
+		$registered_post_types = \get_post_types( array( 'show_in_rest' => true ) );
 		foreach ( $registered_post_types as $registered_post_type ) {
 			\add_filter( 'rest_' . $registered_post_type . '_query', __NAMESPACE__ . '\add_custom_query_params', 10, 2 );
 
@@ -128,7 +128,6 @@ function add_more_sort_by( $query_params ) {
 	$query_params['orderby']['enum'][] = 'post__in';
 	$query_params['orderby']['enum'][] = 'comment_count';
 	$query_params['orderby']['enum'][] = 'name';
-	// die( '<pre>' .print_r( $query_params , 1 ) .'</pre>' );
 	return $query_params;
 }
 
@@ -157,8 +156,6 @@ function add_custom_query_params( $args, $request ) {
 		$args,
 		array_filter( $filtered_query_args )
 	);
-
-	// die( var_dump( $request->get_params() ) );
 
 	return $merged;
 }

--- a/includes/query-loop.php
+++ b/includes/query-loop.php
@@ -98,7 +98,7 @@ if ( ! function_exists( 'add_filter' ) ) {
 \add_action(
 	'init',
 	function () {
-		$registered_post_types = \get_post_types( array( 'show_in_rest' => true ) );
+		$registered_post_types = \get_post_types( array( 'show_in_rest' => true, 'publicly_queryable' => true ) );
 		foreach ( $registered_post_types as $registered_post_type ) {
 			\add_filter( 'rest_' . $registered_post_type . '_query', __NAMESPACE__ . '\add_custom_query_params', 10, 2 );
 


### PR DESCRIPTION
This fix makes it possible to use the extended orderby values for post types which are registered with `show_in_rest = true`, `public = false`, and `publicly_queryable = true`.

This is basically the same as used in https://github.com/ryanwelcher/advanced-query-loop/blob/92db1727b41b4fdab5a9c95a194a9cf88a6a8aa5/src/components/multiple-post-select.js#L16.

Related: https://github.com/humanmade/query-filter/pull/12