### PR TITLE
Fix post type merge issue to retain default post type on frontend

### DIFF
--- a/includes/Traits/Multiple_Posts.php
+++ b/includes/Traits/Multiple_Posts.php
@@ -13,6 +13,12 @@ trait Multiple_Posts {
 	 * Main processing function.
 	 */
 	public function process_multiple_posts(): void {
-		$this->custom_args['post_type'] = array_unique( array_merge( array( $this->default_params['post_type'] ), $this->custom_params['multiple_posts'] ), SORT_REGULAR );
+		$this->custom_args['post_type'] = array_unique(
+			array_merge(
+				(array) $this->default_params['post_type'],
+				(array) $this->custom_params['multiple_posts']
+			),
+			SORT_REGULAR
+		);
 	}
 }


### PR DESCRIPTION
Fix: Ensure default post type is retained when additional post types are selected  

Previously, the `array_merge` call was incorrect, causing the default post type to be ignored on the frontend when additional post types were selected. This fix correctly merges the default and custom post types while ensuring uniqueness using `array_unique()`.  

- Fixed incorrect `array_merge` usage  
- Ensured default post type is included in the query  
- Maintained consistency between editor and frontend  

Closes #111 