### PR TITLE
Fix taxonomy pagination limit - addresses #124

### DIFF
--- a/src/components/taxonomy-query-control.js
+++ b/src/components/taxonomy-query-control.js
@@ -37,7 +37,7 @@ export const TaxonomyQueryControl = ( { attributes, setAttributes } ) => {
 
 	const availableTaxonomies = useSelect( ( select ) =>
 		select( coreStore )
-			.getTaxonomies()
+			.getTaxonomies( { per_page: 50 } )
 			?.filter( ( { types } ) =>
 				types.some( ( type ) =>
 					[ postType, ...multiplePosts ].includes( type )


### PR DESCRIPTION
Fixes #124

This PR addresses the taxonomy pagination limit issue by increasing the default pagination from 10 to 50 taxonomies in the Taxonomy Query Control component.

## Changes Made
- Modified `src/components/taxonomy-query-control.js` line 38-46
- Increased `per_page` parameter from default (10) to 50
- This allows access to custom taxonomies that appear beyond the first 10 results

## Testing
- Tested on a site with custom taxonomies
- These taxonomies were not visible in the AQL interface before the change
- After increasing the pagination limit to 50, both taxonomies became available