### PR TITLE
Allow controls to be filtered at the code level

### DIFF
--- a/includes/Query_Params_Generator.php
+++ b/includes/Query_Params_Generator.php
@@ -21,20 +21,22 @@ class Query_Params_Generator {
 	use Traits\Tax_Query;
 	use Traits\Post_Parent;
 
-
 	/**
-	 * The list of all custom params
+	 * The list of allowed controls and their associated params in the query.
 	 */
-	const KNOWN_PARAMS = array(
-		'multiple_posts',
-		'exclude_current',
-		'include_posts',
-		'meta_query',
-		'date_query',
-		'disable_pagination',
-		'tax_query',
-		'post_parent',
+	const ALLOWED_CONTROLS = array(
+		'additional_post_types'    => 'multiple_posts',
+		'taxonomy_query_builder'   => 'tax_query',
+		'post_meta_query'          => 'meta_query',
+		'post_order'               => 'post_order',
+		'exclude_current_post'     => 'exclude_current',
+		'include_posts'            => 'include_posts',
+		'child_items_only'         => 'child_items_only',
+		'date_query_dynamic_range' => 'date_query',
+		'date_query_relationship'  => 'date_query',
+		'pagination'               => 'disable_pagination',
 	);
+
 
 	/**
 	 * Default values from the default block.
@@ -105,19 +107,30 @@ class Query_Params_Generator {
 		}
 		return false;
 	}
-
 	/**
-	 * Static function to return the list of filtered params.
+	 * Static function to return the list of allowed controls and their associated params in the query.
+	 *
+	 * @return array
 	 */
-	public static function get_known_params() {
-		return \apply_filters( 'aql_allowed_controls', self::KNOWN_PARAMS );
+	public static function get_allowed_controls() {
+		return \apply_filters( 'aql_allowed_controls', array_keys( self::ALLOWED_CONTROLS ) );
+	}
+
+	protected function get_params_to_process() {
+		$params = array();
+		foreach ( self::get_allowed_controls() as $control ) {
+			$params[] = self::ALLOWED_CONTROLS[ $control ];
+		}
+		return $params;
 	}
 
 	/**
 	 * Process all params at once.
 	 */
 	public function process_all(): void {
-		foreach ( self::get_known_params() as $param_name ) {
+		// Get the params from the allowed controls and remove any duplicates.
+		$params = array_unique( $this->get_params_to_process() );
+		foreach ( $params as $param_name ) {
 			if ( $this->has_custom_param( $param_name ) ) {
 				call_user_func( array( $this, 'process_' . $param_name ) );
 			}
@@ -130,5 +143,4 @@ class Query_Params_Generator {
 	public function get_query_args(): array {
 		return $this->custom_args;
 	}
-
 }

--- a/includes/Query_Params_Generator.php
+++ b/includes/Query_Params_Generator.php
@@ -110,7 +110,7 @@ class Query_Params_Generator {
 	 * Static function to return the list of filtered params.
 	 */
 	public static function get_known_params() {
-		return apply_filters( 'aql_allowed_controls', self::KNOWN_PARAMS );
+		return \apply_filters( 'aql_allowed_controls', self::KNOWN_PARAMS );
 	}
 
 	/**

--- a/includes/Query_Params_Generator.php
+++ b/includes/Query_Params_Generator.php
@@ -68,7 +68,6 @@ class Query_Params_Generator {
 		$this->custom_params  = is_array( $custom_params ) ? $custom_params : array();
 	}
 
-
 	/**
 	 * Checks to see if the item that is passed is a post ID.
 	 *
@@ -108,10 +107,17 @@ class Query_Params_Generator {
 	}
 
 	/**
+	 * Static function to return the list of filtered params.
+	 */
+	public static function get_known_params() {
+		return apply_filters( 'aql_allowed_controls', self::KNOWN_PARAMS );
+	}
+
+	/**
 	 * Process all params at once.
 	 */
 	public function process_all(): void {
-		foreach ( self::KNOWN_PARAMS as $param_name ) {
+		foreach ( self::get_known_params() as $param_name ) {
 			if ( $this->has_custom_param( $param_name ) ) {
 				call_user_func( array( $this, 'process_' . $param_name ) );
 			}

--- a/includes/enqueues.php
+++ b/includes/enqueues.php
@@ -35,11 +35,10 @@ if ( ! function_exists( 'add_action' ) ) {
 			);
 			// Allow for translation.
 			wp_set_script_translations( 'advanced-query-loop', 'advanced-query-loop' );
-
 			// Add inline script.
 			wp_add_inline_script(
 				'advanced-query-loop',
-				'aql.controls = ' . json_encode( Query_Params_Generator::get_known_params() ) . ';'
+				'aql.allowedControls = "' . implode( ',', Query_Params_Generator::get_allowed_controls() ) . '";'
 			);
 		}
 

--- a/includes/enqueues.php
+++ b/includes/enqueues.php
@@ -7,7 +7,7 @@
 
 namespace AdvancedQueryLoop;
 
-use function AdvancedQueryLoop\Utils\{ is_gutenberg_plugin_version_or_higher,is_core_version_or_higher };
+use function AdvancedQueryLoop\Utils\{ is_gutenberg_plugin_version_or_higher, is_core_version_or_higher };
 
 
 // Bail on unit tests.
@@ -35,9 +35,15 @@ if ( ! function_exists( 'add_action' ) ) {
 			);
 			// Allow for translation.
 			wp_set_script_translations( 'advanced-query-loop', 'advanced-query-loop' );
+
+			// Add inline script.
+			wp_add_inline_script(
+				'advanced-query-loop',
+				'aql.controls = ' . json_encode( Query_Params_Generator::get_known_params() ) . ';'
+			);
 		}
 
-		// Per Page, Offset, and Max count controls where merged into GB 19.
+		// Per Page, Offset, and Max count controls were merged into GB 19.
 		if ( ! is_gutenberg_plugin_version_or_higher( '19' ) && ! is_core_version_or_higher( '6.7' ) ) {
 			// Enqueue the legacy controls.
 			$pre_gb_19_assets_file = BUILD_DIR_PATH . 'legacy-pre-gb-19.asset.php';

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/unit/bootstrap.php"
          cacheResultFile=".phpunit.cache/test-results"
          executionOrder="depends,defects"
          forceCoversAnnotation="true"

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,42 @@ Sort in ascending or descending order by:
 
 Improve the performance of the query by disabling pagination. This is done automatically when there is now Pagination block in teh Post Template.
 
+## Filtering the available controls
+
+It is possible to remove controls from AQL using the `aql_allowed_controls` filter:
+
+```php
+add_filter(
+	'aql_allowed_controls',
+	function( $controls ) {
+		// Exclude the additional_post_types and taxonomy_query_builder controls.
+		$to_exclude        = array( 'additional_post_types', 'taxonomy_query_builder' );
+		$filtered_controls = array_filter(
+			$controls,
+			function( $control ) use ( $to_exclude ) {
+				if ( ! in_array( $control, $to_exclude, true ) ) {
+					return $control;
+				}
+			},
+		);
+		return $filtered_controls;
+	}
+);
+```
+
+### List of control identifiers
+
+-   `'additional_post_types'`
+-   `'taxonomy_query_builder'`
+-   `'post_meta_query'`
+-   `'post_order'`
+-   `'exclude_current_post'`
+-   `'include_posts'`
+-   `'child_items_only'`
+-   `'date_query_dynamic_range'`
+-   `'date_query_relationship'`
+-   `'pagination'`
+
 ## Extending AQL
 
 Detailed instructions on how to extend AQL as well as an example are available [here](./extending-aql.md)

--- a/readme.md
+++ b/readme.md
@@ -63,7 +63,7 @@ Improve the performance of the query by disabling pagination. This is done autom
 
 ## Filtering the available controls
 
-It is possible to remove controls from AQL using the `aql_allowed_controls` filter:
+It is possible to remove controls from AQL using the `aql_allowed_controls` filter. The filter receives a single parameter containing an array of allowed controls. This can be modified to remove the control from the UI and stop processing the associated query param.
 
 ```php
 add_filter(

--- a/src/components/child-items-toggle.js
+++ b/src/components/child-items-toggle.js
@@ -7,7 +7,11 @@ import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as editorStore } from '@wordpress/editor';
 
-export const ChildItemsToggle = ( { attributes, setAttributes } ) => {
+export const ChildItemsToggle = ( {
+	attributes,
+	setAttributes,
+	allowedControls,
+} ) => {
 	const { query: { post_parent: postParent } = {} } = attributes;
 
 	const { isHierarchial, postTypeName, postID } = useSelect( ( select ) => {
@@ -21,6 +25,11 @@ export const ChildItemsToggle = ( { attributes, setAttributes } ) => {
 			postID: post?.id,
 		};
 	}, [] );
+
+	// If the control is not allowed, return null.
+	if ( ! allowedControls.includes( 'child_items_only' ) ) {
+		return null;
+	}
 
 	return (
 		<ToggleControl

--- a/src/components/multiple-post-select.js
+++ b/src/components/multiple-post-select.js
@@ -6,16 +6,27 @@ import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
-export const MultiplePostSelect = ( { attributes, setAttributes } ) => {
+export const MultiplePostSelect = ( {
+	attributes,
+	setAttributes,
+	allowedControls,
+} ) => {
 	const { query: { multiple_posts: multiplePosts = [], postType } = {} } =
 		attributes;
 
-	const postTypes = useSelect( ( select ) =>
-		select( coreStore )
-			.getPostTypes( { per_page: 50 } )
-			?.filter( ( { viewable } ) => viewable )
-			?.map( ( { slug } ) => slug )
+	const postTypes = useSelect(
+		( select ) =>
+			select( coreStore )
+				.getPostTypes( { per_page: 50 } )
+				?.filter( ( { viewable } ) => viewable )
+				?.map( ( { slug } ) => slug ),
+		[]
 	);
+
+	// If the control is not allowed, return null.
+	if ( ! allowedControls.includes( 'additional_post_types' ) ) {
+		return null;
+	}
 
 	if ( ! postTypes ) {
 		return <div>{ __( 'Loading…', 'advanced-query-loop' ) }</div>;

--- a/src/components/pagination-toggle.js
+++ b/src/components/pagination-toggle.js
@@ -4,9 +4,17 @@
 import { ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export const PaginationToggle = ( { attributes, setAttributes } ) => {
+export const PaginationToggle = ( {
+	attributes,
+	setAttributes,
+	allowedControls,
+} ) => {
 	const { query: { disable_pagination: disablePagination } = {} } =
 		attributes;
+	// If the control is not allowed, return null.
+	if ( ! allowedControls.includes( 'pagination' ) ) {
+		return null;
+	}
 
 	return (
 		<ToggleControl

--- a/src/components/post-date-query-controls.js
+++ b/src/components/post-date-query-controls.js
@@ -8,7 +8,11 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-export const PostDateQueryControls = ( { attributes, setAttributes } ) => {
+export const PostDateQueryControls = ( {
+	attributes,
+	setAttributes,
+	allowedControls,
+} ) => {
 	const {
 		query: {
 			date_query: {
@@ -24,143 +28,155 @@ export const PostDateQueryControls = ( { attributes, setAttributes } ) => {
 	return (
 		<>
 			<h2>{ __( 'Post Date Query', 'advanced-query-loop' ) }</h2>
-			<SelectControl
-				label={ __( 'Dynamic Range', 'advanced-query-loop' ) }
-				help={ __(
-					'Show posts from the last month, 3 months, 6 months, or 12 months. Posts are shown from the 1st of the month.',
-					'advanced-query-loop'
-				) }
-				value={ range }
-				disabled={ relationFromQuery !== '' }
-				options={ [
-					{
-						label: __( 'None', 'advanced-query-loop' ),
-						value: '',
-					},
-					{
-						label: __( 'Last month', 'advanced-query-loop' ),
-						value: 'last-month',
-					},
-					{
-						label: __( 'Last 3 months', 'advanced-query-loop' ),
-						value: 'three-months',
-					},
-					{
-						label: __( 'Last 6 months', 'advanced-query-loop' ),
-						value: 'six-months',
-					},
-					{
-						label: __( 'Last 12 months', 'advanced-query-loop' ),
-						value: 'twelve-months',
-					},
-				] }
-				onChange={ ( newRange ) => {
-					setAttributes( {
-						query: {
-							...attributes.query,
-							date_query: {
-								...attributes.query.date_query,
-								range: newRange,
-							},
-						},
-					} );
-				} }
-				__nextHasNoMarginBottom
-			/>
-			{ range !== '' && (
-				<CheckboxControl
-					label={ __(
-						'Include up to current date',
-						'advanced-query-loop'
-					) }
+			{ allowedControls.includes( 'date_query_dynamic_range' ) && (
+				<SelectControl
+					label={ __( 'Dynamic Range', 'advanced-query-loop' ) }
 					help={ __(
-						'Should the dynamic range include up to the current date?',
+						'Show posts from the last month, 3 months, 6 months, or 12 months. Posts are shown from the 1st of the month.',
 						'advanced-query-loop'
 					) }
-					disabled={ range === '' }
-					checked={ currentDateInRange }
-					onChange={ ( newCurrentDateInRange ) => {
+					value={ range }
+					disabled={ relationFromQuery !== '' }
+					options={ [
+						{
+							label: __( 'None', 'advanced-query-loop' ),
+							value: '',
+						},
+						{
+							label: __( 'Last month', 'advanced-query-loop' ),
+							value: 'last-month',
+						},
+						{
+							label: __( 'Last 3 months', 'advanced-query-loop' ),
+							value: 'three-months',
+						},
+						{
+							label: __( 'Last 6 months', 'advanced-query-loop' ),
+							value: 'six-months',
+						},
+						{
+							label: __(
+								'Last 12 months',
+								'advanced-query-loop'
+							),
+							value: 'twelve-months',
+						},
+					] }
+					onChange={ ( newRange ) => {
 						setAttributes( {
 							query: {
 								...attributes.query,
 								date_query: {
 									...attributes.query.date_query,
-									current_date_in_range:
-										newCurrentDateInRange,
+									range: newRange,
 								},
 							},
 						} );
 					} }
+					__nextHasNoMarginBottom
 				/>
 			) }
-
-			<SelectControl
-				label={ __( 'Date Relationship', 'advanced-query-loop' ) }
-				help={ __(
-					'Show posts before or after the current date, or before, after, or between specific dates.',
-					'advanced-query-loop'
+			{ range !== '' &&
+				allowedControls.includes( 'date_query_dynamic_range' ) && (
+					<CheckboxControl
+						label={ __(
+							'Include up to current date',
+							'advanced-query-loop'
+						) }
+						help={ __(
+							'Should the dynamic range include up to the current date?',
+							'advanced-query-loop'
+						) }
+						disabled={ range === '' }
+						checked={ currentDateInRange }
+						onChange={ ( newCurrentDateInRange ) => {
+							setAttributes( {
+								query: {
+									...attributes.query,
+									date_query: {
+										...attributes.query.date_query,
+										current_date_in_range:
+											newCurrentDateInRange,
+									},
+								},
+							} );
+						} }
+					/>
 				) }
-				value={ relationFromQuery }
-				disabled={ range !== '' }
-				options={ [
-					{
-						label: __( 'None', 'advanced-query-loop' ),
-						value: '',
-					},
-					{
-						label: __(
-							'Before current date',
-							'advanced-query-loop'
-						),
-						value: 'before-current',
-					},
-					{
-						label: __(
-							'After current date',
-							'advanced-query-loop'
-						),
-						value: 'after-current',
-					},
-					{
-						label: __(
-							'Before specific date',
-							'advanced-query-loop'
-						),
-						value: 'before',
-					},
-					{
-						label: __(
-							'After specific date',
-							'advanced-query-loop'
-						),
-						value: 'after',
-					},
-					{
-						label: __(
-							'Between specific dates',
-							'advanced-query-loop'
-						),
-						value: 'between',
-					},
-				] }
-				onChange={ ( relation ) => {
-					setAttributes( {
-						query: {
-							...attributes.query,
-							date_query:
-								relation !== ''
-									? {
-											...attributes.query.date_query,
-											relation,
-									  }
-									: '',
+			{ allowedControls.includes( 'date_query_relationship' ) && (
+				<SelectControl
+					label={ __( 'Date Relationship', 'advanced-query-loop' ) }
+					help={ __(
+						'Show posts before or after the current date, or before, after, or between specific dates.',
+						'advanced-query-loop'
+					) }
+					value={ relationFromQuery }
+					disabled={
+						allowedControls.includes(
+							'date_query_dynamic_range'
+						) && range !== ''
+					}
+					options={ [
+						{
+							label: __( 'None', 'advanced-query-loop' ),
+							value: '',
 						},
-					} );
-				} }
-				__nextHasNoMarginBottom
-			/>
+						{
+							label: __(
+								'Before current date',
+								'advanced-query-loop'
+							),
+							value: 'before-current',
+						},
+						{
+							label: __(
+								'After current date',
+								'advanced-query-loop'
+							),
+							value: 'after-current',
+						},
+						{
+							label: __(
+								'Before specific date',
+								'advanced-query-loop'
+							),
+							value: 'before',
+						},
+						{
+							label: __(
+								'After specific date',
+								'advanced-query-loop'
+							),
+							value: 'after',
+						},
+						{
+							label: __(
+								'Between specific dates',
+								'advanced-query-loop'
+							),
+							value: 'between',
+						},
+					] }
+					onChange={ ( relation ) => {
+						setAttributes( {
+							query: {
+								...attributes.query,
+								date_query:
+									relation !== ''
+										? {
+												...attributes.query.date_query,
+												relation,
+										  }
+										: '',
+							},
+						} );
+					} }
+					__nextHasNoMarginBottom
+				/>
+			) }
 			{ relationFromQuery !== '' &&
-				! relationFromQuery.includes( 'current' ) && (
+				! relationFromQuery.includes( 'current' ) &&
+				allowedControls.includes( 'date_query_relationship' ) && (
 					<>
 						{ relationFromQuery === 'between' && (
 							<h4>

--- a/src/components/post-exclude-controls.js
+++ b/src/components/post-exclude-controls.js
@@ -9,13 +9,18 @@ import { __ } from '@wordpress/i18n';
 /**
  * A component that lets you pick posts to be excluded from the query
  *
- * @param {Object}   props               Component props
- * @param {Object}   props.attributes    Block attributes
- * @param {Function} props.setAttributes Block attributes setter
+ * @param {Object}   props                 Component props
+ * @param {Object}   props.attributes      Block attributes
+ * @param {Function} props.setAttributes   Block attributes setter
+ * @param {Array}    props.allowedControls Allowed controls
  *
  * @return {Element} PostExcludeControls
  */
-export const PostExcludeControls = ( { attributes, setAttributes } ) => {
+export const PostExcludeControls = ( {
+	attributes,
+	setAttributes,
+	allowedControls,
+} ) => {
 	const { query: { exclude_current: excludeCurrent } = {} } = attributes;
 	const { record: siteOptions } = useEntityRecord( 'root', 'site' );
 	const { currentPost, isAdmin } = useSelect( ( select ) => {
@@ -27,6 +32,11 @@ export const PostExcludeControls = ( { attributes, setAttributes } ) => {
 			} ),
 		};
 	}, [] );
+
+	// If the control is not allowed, return null.
+	if ( ! allowedControls.includes( 'exclude_current_post' ) ) {
+		return null;
+	}
 
 	if ( ! currentPost ) {
 		return <div>{ __( 'Loading…', 'advanced-query-loop' ) }</div>;

--- a/src/components/post-include-controls.js
+++ b/src/components/post-include-controls.js
@@ -13,7 +13,11 @@ import { __ } from '@wordpress/i18n';
  *@return {Element} PostIncludeControls
  */
 
-export const PostIncludeControls = ( { attributes, setAttributes } ) => {
+export const PostIncludeControls = ( {
+	attributes,
+	setAttributes,
+	allowedControls,
+} ) => {
 	const {
 		query: {
 			include_posts: includePosts = [],
@@ -68,6 +72,11 @@ export const PostIncludeControls = ( { attributes, setAttributes } ) => {
 			setMultiplePostsState( multiplePosts );
 		}
 	}, [ multiplePosts ] );
+
+	// If the control is not allowed, return null.``
+	if ( ! allowedControls.includes( 'include_posts' ) ) {
+		return null;
+	}
 
 	/**
 	 * Retrieves the ID of a post based on its title.

--- a/src/components/post-meta-query-controls.js
+++ b/src/components/post-meta-query-controls.js
@@ -30,7 +30,11 @@ const combineMetaKeys = ( records ) => {
 };
 
 // A component to render a select control for the post meta query.
-export const PostMetaQueryControls = ( { attributes, setAttributes } ) => {
+export const PostMetaQueryControls = ( {
+	attributes,
+	setAttributes,
+	allowedControls,
+} ) => {
 	const {
 		query: {
 			postType,
@@ -44,8 +48,6 @@ export const PostMetaQueryControls = ( { attributes, setAttributes } ) => {
 
 	const [ selectedPostType ] = useState( postType );
 
-	const registeredMeta = combineMetaKeys( records );
-
 	useEffect( () => {
 		// If the post type changes, reset the meta query.
 		if ( postType !== selectedPostType ) {
@@ -58,6 +60,13 @@ export const PostMetaQueryControls = ( { attributes, setAttributes } ) => {
 			} );
 		}
 	}, [ postType ] );
+
+	// If the control is not allowed, return null.
+	if ( ! allowedControls.includes( 'post_meta_query' ) ) {
+		return null;
+	}
+
+	const registeredMeta = combineMetaKeys( records );
 
 	return (
 		<>

--- a/src/components/post-order-controls.js
+++ b/src/components/post-order-controls.js
@@ -61,8 +61,18 @@ export const sortOptions = [
  * @param {*} param0
  * @return {Element} PostCountControls
  */
-export const PostOrderControls = ( { attributes, setAttributes } ) => {
+export const PostOrderControls = ( {
+	attributes,
+	setAttributes,
+	allowedControls,
+} ) => {
 	const { query: { order, orderBy } = {} } = attributes;
+
+	// If the control is not allowed, return null.
+	if ( ! allowedControls.includes( 'post_order' ) ) {
+		return null;
+	}
+
 	return (
 		<>
 			<SelectControl

--- a/src/components/taxonomy-query-control.js
+++ b/src/components/taxonomy-query-control.js
@@ -26,7 +26,11 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import SingleTaxonomyControl from './single-taxonomy-control';
 
-export const TaxonomyQueryControl = ( { attributes, setAttributes } ) => {
+export const TaxonomyQueryControl = ( {
+	attributes,
+	setAttributes,
+	allowedControls,
+} ) => {
 	const {
 		query: {
 			postType,
@@ -44,6 +48,11 @@ export const TaxonomyQueryControl = ( { attributes, setAttributes } ) => {
 				)
 			)
 	);
+
+	// If the control is not allowed, return null.
+	if ( ! allowedControls.includes( 'taxonomy_query_builder' ) ) {
+		return null;
+	}
 
 	return (
 		<>

--- a/src/variations/controls.js
+++ b/src/variations/controls.js
@@ -46,8 +46,13 @@ const isAdvancedQueryLoop = ( props ) => {
 const withAdvancedQueryControls = ( BlockEdit ) => ( props ) => {
 	// If the is the correct variation, add the custom controls.
 	if ( isAdvancedQueryLoop( props ) ) {
-		const { controls } = window?.aql;
+		const { allowedControls } = window?.aql;
 		const { attributes } = props;
+		const allowedControlsArray = allowedControls.split( ',' );
+		const propsWithControls = {
+			...props,
+			allowedControls: allowedControlsArray,
+		};
 		// If the inherit prop is false or undefined, add all the controls.
 		if ( ! attributes.query.inherit ) {
 			return (
@@ -61,34 +66,21 @@ const withAdvancedQueryControls = ( BlockEdit ) => ( props ) => {
 							) }
 						>
 							<AQLLegacyControls.Slot
-								fillProps={ { ...props } }
+								fillProps={ { ...propsWithControls } }
 							/>
-							{ controls?.multiple_posts && (
-								<MultiplePostSelect { ...props } />
-							) }
-							{ controls?.tax_query && (
-								<TaxonomyQueryControl { ...props } />
-							) }
-							{ controls?.meta_query && (
-								<PostMetaQueryControls { ...props } />
-							) }
-							<PostOrderControls { ...props } />
-							{ controls?.exclude_current && (
-								<PostExcludeControls { ...props } />
-							) }
-							{ controls?.include_posts && (
-								<PostIncludeControls { ...props } />
-							) }
-							{ controls?.post_parent && (
-								<ChildItemsToggle { ...props } />
-							) }
-							{ controls?.date_query && (
-								<PostDateQueryControls { ...props } />
-							) }
-							{ controls?.disable_pagination && (
-								<PaginationToggle { ...props } />
-							) }
-							<AQLControls.Slot fillProps={ { ...props } } />
+
+							<MultiplePostSelect { ...propsWithControls } />
+							<TaxonomyQueryControl { ...propsWithControls } />
+							<PostMetaQueryControls { ...propsWithControls } />
+							<PostOrderControls { ...propsWithControls } />
+							<PostExcludeControls { ...propsWithControls } />
+							<PostIncludeControls { ...propsWithControls } />
+							<ChildItemsToggle { ...propsWithControls } />
+							<PostDateQueryControls { ...propsWithControls } />
+							<PaginationToggle { ...propsWithControls } />
+							<AQLControls.Slot
+								fillProps={ { ...propsWithControls } }
+							/>
 						</PanelBody>
 					</InspectorControls>
 				</>
@@ -105,9 +97,9 @@ const withAdvancedQueryControls = ( BlockEdit ) => ( props ) => {
 							'advanced-query-loop'
 						) }
 					>
-						<PostOrderControls { ...props } />
+						<PostOrderControls { ...propsWithControls } />
 						<AQLControlsInheritedQuery.Slot
-							fillProps={ { ...props } }
+							fillProps={ { ...propsWithControls } }
 						/>
 					</PanelBody>
 				</InspectorControls>

--- a/src/variations/controls.js
+++ b/src/variations/controls.js
@@ -46,8 +46,9 @@ const isAdvancedQueryLoop = ( props ) => {
 const withAdvancedQueryControls = ( BlockEdit ) => ( props ) => {
 	// If the is the correct variation, add the custom controls.
 	if ( isAdvancedQueryLoop( props ) ) {
-		// If the inherit prop is false or undefined,  add all the controls.
+		const { controls } = window?.aql;
 		const { attributes } = props;
+		// If the inherit prop is false or undefined, add all the controls.
 		if ( ! attributes.query.inherit ) {
 			return (
 				<>
@@ -62,15 +63,31 @@ const withAdvancedQueryControls = ( BlockEdit ) => ( props ) => {
 							<AQLLegacyControls.Slot
 								fillProps={ { ...props } }
 							/>
-							<MultiplePostSelect { ...props } />
-							<TaxonomyQueryControl { ...props } />
-							<PostMetaQueryControls { ...props } />
+							{ controls?.multiple_posts && (
+								<MultiplePostSelect { ...props } />
+							) }
+							{ controls?.tax_query && (
+								<TaxonomyQueryControl { ...props } />
+							) }
+							{ controls?.meta_query && (
+								<PostMetaQueryControls { ...props } />
+							) }
 							<PostOrderControls { ...props } />
-							<PostExcludeControls { ...props } />
-							<PostIncludeControls { ...props } />
-							<ChildItemsToggle { ...props } />
-							<PostDateQueryControls { ...props } />
-							<PaginationToggle { ...props } />
+							{ controls?.exclude_current && (
+								<PostExcludeControls { ...props } />
+							) }
+							{ controls?.include_posts && (
+								<PostIncludeControls { ...props } />
+							) }
+							{ controls?.post_parent && (
+								<ChildItemsToggle { ...props } />
+							) }
+							{ controls?.date_query && (
+								<PostDateQueryControls { ...props } />
+							) }
+							{ controls?.disable_pagination && (
+								<PaginationToggle { ...props } />
+							) }
 							<AQLControls.Slot fillProps={ { ...props } } />
 						</PanelBody>
 					</InspectorControls>

--- a/tests/unit/bootstrap.php
+++ b/tests/unit/bootstrap.php
@@ -1,0 +1,6 @@
+<?php
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $tag, $value ) {
+		return $value;
+	}
+}


### PR DESCRIPTION
This PR introduces the `aql_allowed_controls` filter that provides a way for developers to remove existing controls. This has become more important as the plugin grows and provides more options that developers may not need or want exposed to for their clients.

This is not the way to add new controls to AQL and is a first step towards providing a more customized experience for each site AQL is run on.

Closes #61 