### PR TITLE
Post Meta Query updates

### DIFF
--- a/includes/Traits/Meta_Query.php
+++ b/includes/Traits/Meta_Query.php
@@ -25,6 +25,7 @@ trait Meta_Query {
 							'key'     => $query['meta_key'] ?? '',
 							'value'   => $query['meta_value'] ?? '',
 							'compare' => $query['meta_compare'] ?? '',
+							'type'    => $query['meta_type'] ?? '',
 						)
 					);
 				}

--- a/src/components/post-meta-control.js
+++ b/src/components/post-meta-control.js
@@ -64,7 +64,10 @@ export const PostMetaControl = ( {
 
 	useEffect( () => {
 		// This causes advanced mode to be enabled if the meta_type or meta_compare is set and breaks updating.
-		if ( activeQuery?.meta_type || activeQuery?.meta_compare ) {
+		if (
+			( activeQuery?.meta_type && activeQuery?.meta_type !== 'CHAR' ) ||
+			( activeQuery?.meta_compare && activeQuery?.meta_compare !== '=' )
+		) {
 			setAdvancedMode( true );
 			setDisableAdvancedToggle( true );
 		} else {

--- a/src/components/post-meta-control.js
+++ b/src/components/post-meta-control.js
@@ -2,11 +2,12 @@
  * WordPress dependencies
  */
 import {
-	SelectControl,
-	TextControl,
 	Button,
 	FormTokenField,
-	BaseControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalHStack as HStack,
+	SelectControl,
+	TextControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -30,6 +31,11 @@ const compareMetaOptions = [
 	'RLIKE',
 ];
 
+const toggleMargin = {
+	marginTop: '1.5em',
+	marginBottom: '0.75em',
+};
+
 export const PostMetaControl = ( {
 	registeredMetaKeys,
 	id,
@@ -42,14 +48,14 @@ export const PostMetaControl = ( {
 	/**
 	 * Update a query param.
 	 *
-	 * @param {*} queries
-	 * @param {*} queryId
-	 * @param {*} item
-	 * @param {*} value
-	 * @returns
+	 * @param {Array} currentQueries The current queries array
+	 * @param {string} queryId       The query ID to update
+	 * @param {string} item The key to update
+	 * @param {string} value The value to update
+	 * @return {Array} The updated queries array
 	 */
-	const updateQueryParam = ( queries, queryId, item, value ) => {
-		return queries.map( ( query ) => {
+	const updateQueryParam = ( currentQueries, queryId, item, value ) => {
+		return currentQueries.map( ( query ) => {
 			if ( query.id === queryId ) {
 				return {
 					...query,
@@ -62,110 +68,115 @@ export const PostMetaControl = ( {
 
 	return (
 		<>
-			<BaseControl
-				help={ __(
-					'Start typing to search for a meta key or manually enter one.',
-					'advanced-query-loop'
-				) }
+			<FormTokenField
+				label={ __( 'Meta Key', 'advanced-query-loop' ) }
+				value={
+					activeQuery?.meta_key?.length
+						? [ activeQuery.meta_key ]
+						: []
+				}
+				__experimentalShowHowTo={ false }
+				suggestions={ registeredMetaKeys }
+				maxLength={ 1 }
+				onChange={ ( newMeta ) => {
+					setAttributes( {
+						query: {
+							...attributes.query,
+							meta_query: {
+								...attributes.query.meta_query,
+								queries: updateQueryParam(
+									queries,
+									id,
+									'meta_key',
+									newMeta[ 0 ]
+								),
+							},
+						},
+					} );
+				} }
 				__nextHasNoMarginBottom
+			/>
+			{ activeQuery?.meta_key?.length > 0 && (
+				<>
+					<TextControl
+						label={ __( 'Meta Value', 'advanced-query-loop' ) }
+						value={ activeQuery.meta_value }
+						onChange={ ( newValue ) => {
+							setAttributes( {
+								query: {
+									...attributes.query,
+									meta_query: {
+										...attributes.query.meta_query,
+										queries: updateQueryParam(
+											queries,
+											id,
+											'meta_value',
+											newValue
+										),
+									},
+								},
+							} );
+						} }
+					/>
+					<SelectControl
+						label={ __( 'Meta Compare', 'advanced-query-loop' ) }
+						value={ activeQuery.meta_compare }
+						options={ [
+							...compareMetaOptions.map( ( operator ) => {
+								return { label: operator, value: operator };
+							} ),
+						] }
+						onChange={ ( newCompare ) => {
+							setAttributes( {
+								query: {
+									...attributes.query,
+									meta_query: {
+										...attributes.query.meta_query,
+										queries: updateQueryParam(
+											queries,
+											id,
+											'meta_compare',
+											newCompare
+										),
+									},
+								},
+							} );
+						} }
+						__nextHasNoMarginBottom
+					/>
+				</>
+			) }
+			<hr />
+			<HStack
+				alignment={ activeQuery?.meta_key ? 'edge' : 'right' }
+				style={ toggleMargin }
 			>
-				<FormTokenField
-					label={ __( 'Meta Key', 'advanced-query-loop' ) }
-					value={
-						activeQuery?.meta_key?.length
-							? [ activeQuery.meta_key ]
-							: []
-					}
-					__experimentalShowHowTo={ false }
-					suggestions={ registeredMetaKeys }
-					maxLength={ 1 }
-					onChange={ ( newMeta ) => {
+				<Button
+					key={ id }
+					variant="secondary"
+					size="small"
+					isDestructive
+					onClick={ () => {
+						const updatedQueries = queries.filter(
+							( query ) => query.id !== id
+						);
+
 						setAttributes( {
 							query: {
 								...attributes.query,
 								meta_query: {
 									...attributes.query.meta_query,
-									queries: updateQueryParam(
-										queries,
-										id,
-										'meta_key',
-										newMeta[ 0 ]
-									),
+									queries: updatedQueries,
 								},
 							},
 						} );
 					} }
-					__nextHasNoMarginBottom
-				/>
-			</BaseControl>
-			<TextControl
-				label={ __( 'Meta Value', 'advanced-query-loop' ) }
-				value={ activeQuery.meta_value }
-				onChange={ ( newValue ) => {
-					setAttributes( {
-						query: {
-							...attributes.query,
-							meta_query: {
-								...attributes.query.meta_query,
-								queries: updateQueryParam(
-									queries,
-									id,
-									'meta_value',
-									newValue
-								),
-							},
-						},
-					} );
-				} }
-			/>
-			<SelectControl
-				label={ __( 'Meta Compare', 'advanced-query-loop' ) }
-				value={ activeQuery.meta_compare }
-				options={ [
-					...compareMetaOptions.map( ( operator ) => {
-						return { label: operator, value: operator };
-					} ),
-				] }
-				onChange={ ( newCompare ) => {
-					setAttributes( {
-						query: {
-							...attributes.query,
-							meta_query: {
-								...attributes.query.meta_query,
-								queries: updateQueryParam(
-									queries,
-									id,
-									'meta_compare',
-									newCompare
-								),
-							},
-						},
-					} );
-				} }
-				__nextHasNoMarginBottom
-			/>
-			<Button
-				size="small"
-				variant="secondary"
-				isDestructive
-				onClick={ () => {
-					const updatedQueries = queries.filter(
-						( query ) => query.id !== id
-					);
-
-					setAttributes( {
-						query: {
-							...attributes.query,
-							meta_query: {
-								...attributes.query.meta_query,
-								queries: updatedQueries,
-							},
-						},
-					} );
-				} }
-			>
-				{ __( 'Remove meta query', 'advanced-query-loop' ) }
-			</Button>
+				>
+					{ __( 'Remove query', 'advanced-query-loop' ) }
+				</Button>
+			</HStack>
+			<hr />
+			<br />
 		</>
 	);
 };

--- a/src/components/post-meta-control.js
+++ b/src/components/post-meta-control.js
@@ -63,6 +63,7 @@ export const PostMetaControl = ( {
 		useState( false );
 
 	useEffect( () => {
+		// This causes advanced mode to be enabled if the meta_type or meta_compare is set and breaks updating.
 		if ( activeQuery?.meta_type || activeQuery?.meta_compare ) {
 			setAdvancedMode( true );
 			setDisableAdvancedToggle( true );

--- a/src/components/post-meta-control.js
+++ b/src/components/post-meta-control.js
@@ -8,8 +8,10 @@ import {
 	__experimentalHStack as HStack,
 	SelectControl,
 	TextControl,
+	ToggleControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
 
 const compareMetaOptions = [
 	'=',
@@ -31,8 +33,20 @@ const compareMetaOptions = [
 	'RLIKE',
 ];
 
+const metaTypeOptions = [
+	'CHAR',
+	'NUMERIC',
+	'BINARY',
+	'DATE',
+	'DATETIME',
+	'DECIMAL',
+	'SIGNED',
+	'TIME',
+	'UNSIGNED',
+];
+
 const toggleMargin = {
-	marginTop: '1.5em',
+	marginTop: '0.75em',
 	marginBottom: '0.75em',
 };
 
@@ -44,15 +58,27 @@ export const PostMetaControl = ( {
 	setAttributes,
 } ) => {
 	const activeQuery = queries.find( ( query ) => query.id === id );
+	const [ advancedMode, setAdvancedMode ] = useState( false );
+	const [ disableAdvancedToggle, setDisableAdvancedToggle ] =
+		useState( false );
+
+	useEffect( () => {
+		if ( activeQuery?.meta_type || activeQuery?.meta_compare ) {
+			setAdvancedMode( true );
+			setDisableAdvancedToggle( true );
+		} else {
+			setDisableAdvancedToggle( false );
+		}
+	}, [ activeQuery?.meta_type, activeQuery?.meta_compare ] );
 
 	/**
 	 * Update a query param.
 	 *
-	 * @param {Array} currentQueries The current queries array
-	 * @param {string} queryId       The query ID to update
-	 * @param {string} item The key to update
-	 * @param {string} value The value to update
-	 * @return {Array} The updated queries array
+	 * @param {Array}  currentQueries The current queries array
+	 * @param {string} queryId        The query ID to update
+	 * @param {string} item           The key to update
+	 * @param {string} value          The value to update
+	 * @return {Array}                The updated queries array
 	 */
 	const updateQueryParam = ( currentQueries, queryId, item, value ) => {
 		return currentQueries.map( ( query ) => {
@@ -94,7 +120,6 @@ export const PostMetaControl = ( {
 						},
 					} );
 				} }
-				__nextHasNoMarginBottom
 			/>
 			{ activeQuery?.meta_key?.length > 0 && (
 				<>
@@ -118,32 +143,73 @@ export const PostMetaControl = ( {
 							} );
 						} }
 					/>
-					<SelectControl
-						label={ __( 'Meta Compare', 'advanced-query-loop' ) }
-						value={ activeQuery.meta_compare }
-						options={ [
-							...compareMetaOptions.map( ( operator ) => {
-								return { label: operator, value: operator };
-							} ),
-						] }
-						onChange={ ( newCompare ) => {
-							setAttributes( {
-								query: {
-									...attributes.query,
-									meta_query: {
-										...attributes.query.meta_query,
-										queries: updateQueryParam(
-											queries,
-											id,
-											'meta_compare',
-											newCompare
-										),
-									},
-								},
-							} );
-						} }
-						__nextHasNoMarginBottom
-					/>
+					{ advancedMode && (
+						<>
+							<SelectControl
+								label={ __(
+									'Meta Compare',
+									'advanced-query-loop'
+								) }
+								value={ activeQuery.meta_compare }
+								options={ [
+									...compareMetaOptions.map( ( operator ) => {
+										return {
+											label: operator,
+											value: operator,
+										};
+									} ),
+								] }
+								onChange={ ( newCompare ) => {
+									setAttributes( {
+										query: {
+											...attributes.query,
+											meta_query: {
+												...attributes.query.meta_query,
+												queries: updateQueryParam(
+													queries,
+													id,
+													'meta_compare',
+													newCompare
+												),
+											},
+										},
+									} );
+								} }
+							/>
+							<SelectControl
+								label={ __(
+									'Meta Type',
+									'advanced-query-loop'
+								) }
+								value={ activeQuery.meta_type }
+								options={ [
+									...metaTypeOptions.map( ( type ) => {
+										return {
+											label: type,
+											value: type,
+										};
+									} ),
+								] }
+								onChange={ ( newType ) => {
+									setAttributes( {
+										query: {
+											...attributes.query,
+											meta_query: {
+												...attributes.query.meta_query,
+												queries: updateQueryParam(
+													queries,
+													id,
+													'meta_type',
+													newType
+												),
+											},
+										},
+									} );
+								} }
+								__nextHasNoMarginBottom
+							/>
+						</>
+					) }
 				</>
 			) }
 			<hr />
@@ -151,6 +217,14 @@ export const PostMetaControl = ( {
 				alignment={ activeQuery?.meta_key ? 'edge' : 'right' }
 				style={ toggleMargin }
 			>
+				{ activeQuery?.meta_key && (
+					<ToggleControl
+						checked={ advancedMode }
+						label={ __( 'Advanced mode', 'advanced-query-loop' ) }
+						onChange={ () => setAdvancedMode( ! advancedMode ) }
+						disabled={ disableAdvancedToggle }
+					/>
+				) }
 				<Button
 					key={ id }
 					variant="secondary"

--- a/src/components/post-meta-query-controls.js
+++ b/src/components/post-meta-query-controls.js
@@ -6,7 +6,15 @@ import { v4 as uuidv4 } from 'uuid';
 /**
  * WordPress dependencies
  */
-import { Button, SelectControl, PanelBody } from '@wordpress/components';
+import {
+	Button,
+	Dropdown,
+	__experimentalDropdownContentWrapper as DropdownContentWrapper,
+	PanelBody,
+	ToggleControl,
+	Panel,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEntityRecords } from '@wordpress/core-data';
 import { useEffect, useState } from '@wordpress/element';
@@ -61,99 +69,160 @@ export const PostMetaQueryControls = ( { attributes, setAttributes } ) => {
 
 	return (
 		<>
-			<h2>{ __( 'Post Meta Query', 'advanced-query-loop' ) }</h2>
-			<>
-				{ queries.length > 1 && (
-					<SelectControl
-						label={ __(
-							'Query Relationship',
-							'advanced-query-loop'
-						) }
-						value={ relationFromQuery }
-						options={ [
-							{ label: 'Choose relationship', value: '' },
-							{ label: 'AND', value: 'AND' },
-							{ label: 'OR', value: 'OR' },
-						] }
-						onChange={ ( relation ) =>
-							setAttributes( {
-								query: {
-									...attributes.query,
-									meta_query: {
-										...attributes.query.meta_query,
-										relation,
-									},
-								},
-							} )
-						}
-						__nextHasNoMarginBottom
-					/>
+			<Dropdown
+				popoverProps={ {
+					placement: 'left-start',
+					offset: 36,
+				} }
+				renderToggle={ ( { isOpen, onToggle } ) => (
+					<Button
+						variant="primary"
+						onClick={ onToggle }
+						aria-haspopup="true"
+						aria-expanded={ isOpen }
+						disabled={ Object.keys( registeredMeta ).length === 0 }
+					>
+						{ isOpen
+							? __(
+									'Close Meta Query Builder',
+									'advanced-query-loop'
+							  )
+							: __(
+									'Open Meta Query Builder',
+									'advanced-query-loop'
+							  ) }
+					</Button>
 				) }
+				renderContent={ () => (
+					<DropdownContentWrapper
+						paddingSize="none"
+						style={ { width: '30rem' } }
+					>
+						<Panel
+							header={ __(
+								'Meta Query Builder',
+								'advanced-query-loop'
+							) }
+						>
+							<PanelBody>
+								{ queries.length > 1 && (
+									<>
+										<ToggleControl
+											label={ __(
+												'Combine filters',
+												'advanced-query-loop'
+											) }
+											help={ __(
+												'By default, filters are combined with the OR operator. Enable this option to combine filters with the AND operator.',
+												'advanced-query-loop'
+											) }
+											checked={
+												relationFromQuery === 'AND'
+											}
+											onChange={ () => {
+												setAttributes( {
+													query: {
+														...attributes.query,
+														meta_query: {
+															...attributes.query
+																.meta_query,
+															relation:
+																attributes.query
+																	.meta_query
+																	.relation ===
+																'OR'
+																	? 'AND'
+																	: 'OR',
+														},
+													},
+												} );
+											} }
+											__nextHasNoMarginBottom={ false }
+										/>
+										<hr />
+									</>
+								) }
 
-				{ queries.length < 1 && (
-					<p>
-						{ __(
-							'Add a meta query to select post meta to query',
-							'advanced-query-loop'
-						) }
-					</p>
-				) }
+								{ queries.map(
+									( {
+										id,
+										meta_key: metaKey,
+										meta_value: metaValue,
+										compare,
+									} ) => {
+										return (
+											<PostMetaControl
+												key={ id }
+												id={ id }
+												metaKey={ metaKey }
+												metaValue={ metaValue }
+												metaCompare={ compare }
+												registeredMetaKeys={ Object.keys(
+													registeredMeta
+												) }
+												queries={ queries }
+												attributes={ attributes }
+												setAttributes={ setAttributes }
+											/>
+										);
+									}
+								) }
 
-				{ queries.map(
-					( {
-						id,
-						meta_key: metaKey,
-						meta_value: metaValue,
-						compare,
-					} ) => {
-						return (
-							<PanelBody key={ id }>
-								<PostMetaControl
-									id={ id }
-									metaKey={ metaKey }
-									metaValue={ metaValue }
-									metaCompare={ compare }
-									registeredMetaKeys={ Object.keys(
-										registeredMeta
+								<HStack>
+									<Button
+										variant="primary"
+										onClick={ () => {
+											const newQueries = [
+												...queries,
+												{
+													id: uuidv4(),
+													meta_key: '',
+													meta_value: '',
+													meta_compare: '',
+												},
+											];
+											setAttributes( {
+												query: {
+													...attributes.query,
+													meta_query: {
+														...attributes.query
+															.meta_query,
+														queries: newQueries,
+													},
+												},
+											} );
+										} }
+									>
+										{ __(
+											'Add new query',
+											'advanced-query-loop'
+										) }
+									</Button>
+									{ queries.length > 0 && (
+										<Button
+											variant="primary"
+											isDestructive
+											onClick={ () => {
+												setAttributes( {
+													query: {
+														...attributes.query,
+														meta_query: {},
+													},
+												} );
+											} }
+										>
+											{ __(
+												'Reset queries',
+												'advanced-query-loop'
+											) }
+										</Button>
 									) }
-									queries={ queries }
-									attributes={ attributes }
-									setAttributes={ setAttributes }
-								/>
+								</HStack>
 							</PanelBody>
-						);
-					}
+						</Panel>
+					</DropdownContentWrapper>
 				) }
-				<Button
-					isSmall
-					variant="primary"
-					__next40pxDefaultSize
-					onClick={ () => {
-						const newQueries = [
-							...queries,
-							{
-								id: uuidv4(),
-								meta_key: '',
-								meta_value: '',
-								meta_compare: '',
-							},
-						];
-						setAttributes( {
-							query: {
-								...attributes.query,
-								meta_query: {
-									...attributes.query.meta_query,
-									queries: newQueries,
-								},
-							},
-						} );
-					} }
-				>
-					{ __( 'Add meta query', 'advanced-query-loop' ) }
-				</Button>
-				<br />
-				<br />
-			</>
+			/>
 		</>
 	);
 };

--- a/src/components/post-meta-query-controls.js
+++ b/src/components/post-meta-query-controls.js
@@ -119,11 +119,11 @@ export const PostMetaQueryControls = ( {
 									<>
 										<ToggleControl
 											label={ __(
-												'Match Any Filter',
+												'Match Any Condition',
 												'advanced-query-loop'
 											) }
 											help={ __(
-												'By default, filters are combined using the AND operator, meaning all filter conditions must be met. Enable this option to use the OR operator instead, allowing results that match any of the filter conditions.',
+												'By default, conditions are combined using the AND operator, meaning all conditions must be met. Enable this option to use the OR operator instead, allowing results that match any of the conditions.',
 												'advanced-query-loop'
 											) }
 											checked={

--- a/src/components/post-meta-query-controls.js
+++ b/src/components/post-meta-query-controls.js
@@ -92,10 +92,15 @@ export const PostMetaQueryControls = ( {
 						aria-expanded={ isOpen }
 						disabled={ Object.keys( registeredMeta ).length === 0 }
 					>
-						{ __(
-							'Post Meta query builder',
-							'advanced-query-loop'
-						) }
+						{ isOpen
+							? __(
+									'Close Post meta query builder',
+									'advanced-query-loop'
+							  )
+							: __(
+									'Open Post Meta query builder',
+									'advanced-query-loop'
+							  ) }
 					</Button>
 				) }
 				renderContent={ () => (

--- a/src/components/post-meta-query-controls.js
+++ b/src/components/post-meta-query-controls.js
@@ -1,3 +1,4 @@
+/* eslint-disable @wordpress/no-unsafe-wp-apis */
 /**
  * External dependencies
  */
@@ -23,6 +24,7 @@ import { useEffect, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { PostMetaControl } from './post-meta-control';
+import useRegisteredMeta from '../hooks/useRegisteredMeta';
 
 /**
  * Converts the meta keys from the all sources into a single array.
@@ -53,7 +55,6 @@ export const PostMetaQueryControls = ( {
 	const { records } = useEntityRecords( 'postType', postType, {
 		per_page: 1,
 	} );
-
 	const [ selectedPostType ] = useState( postType );
 
 	useEffect( () => {
@@ -62,7 +63,7 @@ export const PostMetaQueryControls = ( {
 			setAttributes( {
 				query: {
 					...attributes.query,
-					include_posts: [],
+					// include_posts: [],
 					meta_query: {},
 				},
 			} );
@@ -85,21 +86,16 @@ export const PostMetaQueryControls = ( {
 				} }
 				renderToggle={ ( { isOpen, onToggle } ) => (
 					<Button
-						variant="primary"
+						variant={ isOpen ? 'primary' : 'secondary' }
 						onClick={ onToggle }
 						aria-haspopup="true"
 						aria-expanded={ isOpen }
 						disabled={ Object.keys( registeredMeta ).length === 0 }
 					>
-						{ isOpen
-							? __(
-									'Close Meta Query Builder',
-									'advanced-query-loop'
-							  )
-							: __(
-									'Open Meta Query Builder',
-									'advanced-query-loop'
-							  ) }
+						{ __(
+							'Post Meta query builder',
+							'advanced-query-loop'
+						) }
 					</Button>
 				) }
 				renderContent={ () => (
@@ -118,15 +114,15 @@ export const PostMetaQueryControls = ( {
 									<>
 										<ToggleControl
 											label={ __(
-												'Combine filters',
+												'Match Any Filter',
 												'advanced-query-loop'
 											) }
 											help={ __(
-												'By default, filters are combined with the OR operator. Enable this option to combine filters with the AND operator.',
+												'By default, filters are combined using the AND operator, meaning all filter conditions must be met. Enable this option to use the OR operator instead, allowing results that match any of the filter conditions.',
 												'advanced-query-loop'
 											) }
 											checked={
-												relationFromQuery === 'AND'
+												relationFromQuery === 'OR'
 											}
 											onChange={ () => {
 												setAttributes( {

--- a/src/components/taxonomy-query-control.js
+++ b/src/components/taxonomy-query-control.js
@@ -63,21 +63,16 @@ export const TaxonomyQueryControl = ( {
 				} }
 				renderToggle={ ( { isOpen, onToggle } ) => (
 					<Button
-						variant="primary"
+						variant={ isOpen ? 'primary' : 'secondary' }
 						onClick={ onToggle }
 						aria-haspopup="true"
 						aria-expanded={ isOpen }
 						disabled={ availableTaxonomies.length === 0 }
 					>
-						{ isOpen
-							? __(
-									'Close Taxonomy Query Builder',
-									'advanced-query-loop'
-							  )
-							: __(
-									'Open Taxonomy Query Builder',
-									'advanced-query-loop'
-							  ) }
+						{ __(
+							'Taxonomy query builder',
+							'advanced-query-loop'
+						) }
 					</Button>
 				) }
 				renderContent={ () => (

--- a/src/components/taxonomy-query-control.js
+++ b/src/components/taxonomy-query-control.js
@@ -69,10 +69,15 @@ export const TaxonomyQueryControl = ( {
 						aria-expanded={ isOpen }
 						disabled={ availableTaxonomies.length === 0 }
 					>
-						{ __(
-							'Taxonomy query builder',
-							'advanced-query-loop'
-						) }
+						{ isOpen
+							? __(
+									'Close Taxonomy query builder',
+									'advanced-query-loop'
+							  )
+							: __(
+									'Open Taxonomy query builder',
+									'advanced-query-loop'
+							  ) }
 					</Button>
 				) }
 				renderContent={ () => (

--- a/src/hooks/useRegisteredMeta.js
+++ b/src/hooks/useRegisteredMeta.js
@@ -1,0 +1,18 @@
+/**
+ * WordPress Dependencies
+ */
+import { useState } from '@wordpress/element';
+import { select } from '@wordpress/data';
+
+function useRegisteredMeta( listOfPostTypes ) {
+	console.log( listOfPostTypes );
+	const [ meta, setMeta ] = useState();
+	const results = listOfPostTypes.map( ( item ) =>
+		select( 'core' ).getEntityRecords( 'postType', item, {
+			per_page: 1,
+		} )
+	);
+	console.log( results );
+}
+
+export default useRegisteredMeta;

--- a/src/variations/controls.js
+++ b/src/variations/controls.js
@@ -1,9 +1,14 @@
+/* eslint-disable @wordpress/no-unsafe-wp-apis */
 /**
  * WordPress dependencies
  */
 import { addFilter } from '@wordpress/hooks';
 import { InspectorControls } from '@wordpress/block-editor';
-import { PanelBody } from '@wordpress/components';
+import {
+	PanelBody,
+	__experimentalVStack as VStack,
+	BaseControl,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { createBlock } from '@wordpress/blocks';
 
@@ -70,8 +75,22 @@ const withAdvancedQueryControls = ( BlockEdit ) => ( props ) => {
 							/>
 
 							<MultiplePostSelect { ...propsWithControls } />
-							<TaxonomyQueryControl { ...propsWithControls } />
-							<PostMetaQueryControls { ...propsWithControls } />
+							<BaseControl
+								label={ __(
+									'Query Builders',
+									'advanced-query-loop'
+								) }
+								id="query-builders"
+							>
+								<VStack alignment="center">
+									<TaxonomyQueryControl
+										{ ...propsWithControls }
+									/>
+									<PostMetaQueryControls
+										{ ...propsWithControls }
+									/>
+								</VStack>
+							</BaseControl>
 							<PostOrderControls { ...propsWithControls } />
 							<PostExcludeControls { ...propsWithControls } />
 							<PostIncludeControls { ...propsWithControls } />


### PR DESCRIPTION
This PR converts the existing post meta query tools to follow the same UI as the taxonomy builder. Additionally, it adds a new control to set the `meta_type` parameter.

Closes #99 