### PR TITLE
Child pages trait was not being called

### DIFF
--- a/includes/Query_Params_Generator.php
+++ b/includes/Query_Params_Generator.php
@@ -31,7 +31,7 @@ class Query_Params_Generator {
 		'post_order'               => 'post_order',
 		'exclude_current_post'     => 'exclude_current',
 		'include_posts'            => 'include_posts',
-		'child_items_only'         => 'child_items_only',
+		'child_items_only'         => 'post_parent',
 		'date_query_dynamic_range' => 'date_query',
 		'date_query_relationship'  => 'date_query',
 		'pagination'               => 'disable_pagination',

--- a/includes/Traits/Post_Parent.php
+++ b/includes/Traits/Post_Parent.php
@@ -21,7 +21,9 @@ trait Post_Parent {
 		} else {
 			// This is usually when this was set on a template.
 			global $post;
-			$this->custom_args['post_parent'] = $post->ID;
+			if ( isset( $post ) ) {
+				$this->custom_args['post_parent'] = $post->ID;
+			}
 		}
 	}
 }

--- a/includes/query-loop.php
+++ b/includes/query-loop.php
@@ -98,7 +98,7 @@ if ( ! function_exists( 'add_filter' ) ) {
 \add_action(
 	'init',
 	function () {
-		$registered_post_types = \get_post_types( array( 'show_in_rest' => true, 'publicly_queryable' => true ) );
+		$registered_post_types = \get_post_types( array( 'show_in_rest' => true, 'public' => true ) );
 		foreach ( $registered_post_types as $registered_post_type ) {
 			\add_filter( 'rest_' . $registered_post_type . '_query', __NAMESPACE__ . '\add_custom_query_params', 10, 2 );
 


### PR DESCRIPTION
This PR fixes #131 that was a regression as part of #126. The trait was not being called correctly as the name of the param was incorrect.

This PR also fixes an issue with the `page` post type not being included in the `get_post_types` call that was introduced with the changes in #110. Pages are not set to `publicly_queryable`.  I have set the argument to `public` instead

Closes #131 