### PR TITLE
Fix Exclude current post for synced patterns and template.

### DIFF
--- a/includes/Traits/Exclude_Current.php
+++ b/includes/Traits/Exclude_Current.php
@@ -20,23 +20,35 @@ trait Exclude_Current {
 	/**
 	 * Helper to generate the array
 	 *
-	 * @param mixed $to_exclude The value to be excluded.
+	 * @param int $exclude_current_post The value to be excluded.
 	 *
 	 * @return array The ids to exclude
 	 */
-	public function get_exclude_ids( $to_exclude ) {
+	public function get_exclude_ids( $exclude_current_post ) {
 		// If there are already posts to be excluded, we need to add to them.
-		$exclude_ids = $this->custom_args['post__not_in'] ?? array();
-
-		if ( $this->is_post_id( $to_exclude ) ) {
-			array_push( $exclude_ids, intval( $to_exclude ) );
+		$exclude_ids     = $this->custom_args['post__not_in'] ?? array();
+		$post_to_exclude = 0;
+		if ( true !== $exclude_current_post && is_numeric( $exclude_current_post ) && $exclude_current_post >= 1 ) {
+			$post_to_exclude = intval( $exclude_current_post );
 		} else {
-			// This is usually when this was set on a template.
-			global $post;
-			if ( $post ) {
-				array_push( $exclude_ids, $post->ID );
+			// Try to get the queried object ID (frontend context)
+			if ( function_exists( 'get_queried_object_id' ) ) {
+				$post_to_exclude = get_queried_object_id();
+			}
+
+			// Fallback to global $post (editor, unit tests, etc.)
+			if ( ! $post_to_exclude ) {
+				global $post;
+				if ( $post && isset( $post->ID ) ) {
+					$post_to_exclude = $post->ID;
+				}
 			}
 		}
+
+		if ( $post_to_exclude > 0 ) {
+			array_push( $exclude_ids, intval( $post_to_exclude ) );
+		}
+
 		return $exclude_ids;
 	}
 }

--- a/src/components/post-exclude-controls.js
+++ b/src/components/post-exclude-controls.js
@@ -91,9 +91,15 @@ const ExcludeCurrentPostControl = ( {
 
 	const isDisabled = () => {
 		// If the user is not an admin, they cannot edit template anyway
-		if ( ! isAdmin ) {
+		if ( ! isAdmin || ! currentPost ) {
 			return false;
 		}
+
+		// Only disable if we're editing a template AND it's in the list
+		if ( currentPost.type !== 'wp_template' ) {
+			return false;
+		}
+
 		const templatesToExclude = [ 'archive', 'search' ];
 		const {
 			show_on_front: showOnFront, // What is the front page set to show? Options: 'posts' or 'page'
@@ -102,10 +108,7 @@ const ExcludeCurrentPostControl = ( {
 			...templatesToExclude,
 			...( showOnFront === 'posts' ? [ 'home', 'front-page' ] : [] ),
 		];
-		return (
-			currentPost.type === 'wp_template' &&
-			disabledTemplates.includes( currentPost.slug )
-		);
+		return disabledTemplates.includes( currentPost.slug );
 	};
 
 	return (
@@ -118,7 +121,7 @@ const ExcludeCurrentPostControl = ( {
 				setAttributes( {
 					query: {
 						...attributes.query,
-						exclude_current: value ? currentPost.id : 0,
+						exclude_current: value,
 					},
 				} );
 			} }

--- a/tests/e2e/Playground.ts
+++ b/tests/e2e/Playground.ts
@@ -30,7 +30,7 @@ export class Playground {
 				},
 			],
 			blueprint,
-			port: 8889,
+			port: 9876,
 			quiet: true,
 		} );
 		this.handler = this.cliServer.requestHandler;

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig( {
 	use: {
 		/* Collect trace when retrying the failed test. */
 		trace: 'on-first-retry',
-		baseURL: 'http://127.0.0.1:8889/',
+		baseURL: 'http://127.0.0.1:9876/',
 	},
 
 	/* Configure projects for major browsers */

--- a/tests/e2e/tests/README-exclude-current-post.md
+++ b/tests/e2e/tests/README-exclude-current-post.md
@@ -1,0 +1,59 @@
+# Exclude Current Post E2E Tests
+
+This test suite covers the "Exclude Current Post" control functionality in the Advanced Query Loop block.
+
+## Test Coverage
+
+### ✅ Tests for Regular Posts
+
+1. **Initial state** - Verifies the control is visible and unchecked by default
+2. **Toggle on** - Verifies toggling the control on stores `true` in block attributes
+3. **Toggle off** - Verifies toggling the control off stores `false` in block attributes
+4. **Not disabled** - Verifies the control is enabled in regular posts
+
+## Running the Tests
+
+```bash
+# Run all exclude current post tests
+npm run test:e2e -- tests/exclude-current-post.spec.ts
+
+# Run with UI
+npm run test:e2e:ui -- tests/exclude-current-post.spec.ts
+```
+
+## Future Test Additions
+
+The following test scenarios were planned but require additional setup/configuration:
+
+### Templates
+- Should be disabled in archive template
+- Should be disabled in search template
+- Should be disabled in home/front-page templates (when show_on_front is 'posts')
+- Should be enabled in single template
+- Should work in single template and store boolean value
+
+### Synced Patterns
+- Should be visible and functional in a synced pattern
+- Synced pattern with exclude current should work when inserted in a post
+
+These tests require:
+- Proper theme configuration in the test environment
+- Site Editor navigation that works reliably with Playground
+- Pattern creation workflow that's compatible with the test environment
+
+## Test Structure
+
+All tests follow the same pattern:
+1. Initialize Playground with blueprint
+2. Visit post editor
+3. Insert AQL block with custom query
+4. Interact with "Exclude Current Post" control
+5. Assert expected behavior
+6. Clean up Playground instance
+
+## Notes
+
+- Tests use WordPress Playground via `@wp-playground/cli` for isolated testing
+- Each test gets a fresh WordPress instance
+- The `insertAQL` utility handles block insertion and variation selection
+- Tests verify both UI state and block attributes

--- a/tests/e2e/tests/exclude-current-post.spec.ts
+++ b/tests/e2e/tests/exclude-current-post.spec.ts
@@ -106,17 +106,11 @@ test.describe( 'Exclude Current Post - Frontend Rendering', () => {
 		editor,
 		admin,
 	} ) => {
-		// Create multiple test posts first
-		const postTitles = [
-			'Test Post Alpha',
-			'Test Post Beta',
-			'Test Post Gamma',
-		];
+		test.setTimeout( 60000 );
 
-		for ( const title of postTitles ) {
-			await admin.createNewPost( { title } );
-			await editor.publishPost();
-		}
+		// Create one test post - enough to verify exclusion without slowing CI.
+		await admin.createNewPost( { title: 'Test Post Alpha' } );
+		await editor.publishPost();
 
 		// Create the main post with AQL block
 		await admin.createNewPost( { title: 'Main Post with AQL' } );

--- a/tests/e2e/tests/exclude-current-post.spec.ts
+++ b/tests/e2e/tests/exclude-current-post.spec.ts
@@ -1,0 +1,343 @@
+/**
+ * Import our custom test fixtures.
+ */
+import { test, expect } from '../aql-fixtures';
+
+/**
+ * Internal dependencies.
+ */
+import { insertAQL } from '../utils';
+
+test.describe( 'Exclude Current Post', () => {
+	test.beforeEach( async ( { page, editor, playground, admin } ) => {
+		await playground.init( { page, editor } );
+		await admin.visitAdminPage( 'post-new.php' );
+
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+			fullscreenMode: false,
+		} );
+		await insertAQL( { editor, page } );
+	} );
+
+	test.afterEach( async ( { playground } ) => {
+		await playground.cleanUp();
+	} );
+
+	test( 'Initial state - should be visible and unchecked', async ( {
+		page,
+		editor,
+	} ) => {
+		await expect(
+			page.getByRole( 'checkbox', {
+				name: 'Exclude Current Post',
+			} )
+		).toBeVisible();
+
+		await expect(
+			page.getByRole( 'checkbox', {
+				name: 'Exclude Current Post',
+			} )
+		).not.toBeChecked();
+
+		const blocks = await editor.getBlocks();
+
+		expect(
+			blocks[ 0 ].attributes.query.exclude_current
+		).toBeUndefined();
+	} );
+
+	test( 'Should toggle on and store true', async ( { page, editor } ) => {
+		await page
+			.getByRole( 'checkbox', { name: 'Exclude Current Post' } )
+			.click();
+
+		await expect(
+			page.getByRole( 'checkbox', {
+				name: 'Exclude Current Post',
+			} )
+		).toBeChecked();
+
+		const blocks = await editor.getBlocks();
+
+		expect( blocks[ 0 ].attributes.query.exclude_current ).toEqual(
+			true
+		);
+	} );
+
+	test( 'Should toggle off and store false', async ( { page, editor } ) => {
+		// Toggle on first
+		await page
+			.getByRole( 'checkbox', { name: 'Exclude Current Post' } )
+			.click();
+
+		// Then toggle off
+		await page
+			.getByRole( 'checkbox', { name: 'Exclude Current Post' } )
+			.click();
+
+		await expect(
+			page.getByRole( 'checkbox', {
+				name: 'Exclude Current Post',
+			} )
+		).not.toBeChecked();
+
+		const blocks = await editor.getBlocks();
+
+		expect( blocks[ 0 ].attributes.query.exclude_current ).toEqual(
+			false
+		);
+	} );
+
+	test( 'Should not be disabled in a regular post', async ( { page } ) => {
+		await expect(
+			page.getByRole( 'checkbox', {
+				name: 'Exclude Current Post',
+			} )
+		).toBeEnabled();
+	} );
+} );
+
+test.describe( 'Exclude Current Post - Frontend Rendering', () => {
+	test.beforeEach( async ( { page, editor, playground, admin } ) => {
+		await playground.init( { page, editor } );
+	} );
+
+	test.afterEach( async ( { playground } ) => {
+		await playground.cleanUp();
+	} );
+
+	test( 'Should exclude current post from query results on frontend', async ( {
+		page,
+		editor,
+		admin,
+	} ) => {
+		// Create multiple test posts first
+		const postTitles = [
+			'Test Post Alpha',
+			'Test Post Beta',
+			'Test Post Gamma',
+		];
+
+		for ( const title of postTitles ) {
+			await admin.createNewPost( { title } );
+			await editor.publishPost();
+		}
+
+		// Create the main post with AQL block
+		await admin.createNewPost( { title: 'Main Post with AQL' } );
+
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+			fullscreenMode: false,
+		} );
+
+		// Insert AQL block
+		await insertAQL( { editor, page } );
+
+		// Enable "Exclude Current Post"
+		await page
+			.getByRole( 'checkbox', { name: 'Exclude Current Post' } )
+			.click();
+
+		// Verify it's enabled
+		await expect(
+			page.getByRole( 'checkbox', { name: 'Exclude Current Post' } )
+		).toBeChecked();
+
+		// Publish the post
+		await editor.publishPost();
+
+		// Get the post URL from the publish panel
+		const postUrl = await page
+			.locator( '.post-publish-panel__postpublish-buttons a' )
+			.first()
+			.getAttribute( 'href' );
+
+		expect( postUrl ).toBeTruthy();
+
+		// Navigate to the frontend
+		await page.goto( postUrl! );
+
+		// Wait for the page to load
+		await page.waitForLoadState( 'networkidle' );
+
+		// Save screenshot for debugging
+		await page.screenshot( { path: 'test-results/frontend-page.png', fullPage: true } );
+
+		// Check if there are ANY query loops on the page
+		const allQueryLoops = page.locator( '.wp-block-query' );
+		const queryLoopCount = await allQueryLoops.count();
+		console.log( `Found ${ queryLoopCount } query loop(s) on the page` );
+
+		// If no query loops found, the block might not be rendering
+		if ( queryLoopCount === 0 ) {
+			console.log( 'No query loops found! Block may not be rendering.' );
+			// Save HTML for inspection
+			const html = await page.content();
+			console.log( 'Page HTML sample:', html.substring( 0, 1000 ) );
+		}
+
+		// Just check ALL post links on the page for now
+		const allPostLinks = page.locator( '.wp-block-post-title a' );
+		const postLinkCount = await allPostLinks.count();
+		console.log( `Found ${ postLinkCount } post link(s) on the page` );
+
+		// Verify we have posts displayed
+		if ( postLinkCount === 0 ) {
+			throw new Error( 'No post links found on the page' );
+		}
+
+		await expect( allPostLinks.first() ).toBeVisible();
+
+		// Get the text content of all displayed post titles
+		const displayedTitles = await allPostLinks.allTextContents();
+
+		console.log( 'All displayed post titles:', displayedTitles );
+
+		// TEMPORARY: Since we can't reliably distinguish between theme query loops
+		// and our AQL block, we're going to mark this as a known limitation
+		// and adjust our test expectations
+
+		// The theme's query loop will show ALL posts
+		// Our AQL block should NOT show the current post
+		// But we can't easily tell them apart in the rendered HTML
+
+		// For now, let's verify that our AQL-specific functionality works
+		// by checking if MOST occurrences exclude the current post
+
+		// Count occurrences of each post title
+		const mainPostCount = displayedTitles.filter( t => t === 'Main Post with AQL' ).length;
+		const alphaCount = displayedTitles.filter( t => t === 'Test Post Alpha' ).length;
+
+		console.log( `"Main Post with AQL" appears ${ mainPostCount } time(s)` );
+		console.log( `"Test Post Alpha" appears ${ alphaCount } time(s)` );
+
+		// The test posts should appear more frequently than the main post
+		// because the AQL block should exclude the main post
+		expect( mainPostCount ).toBeLessThan( alphaCount );
+	} );
+
+	test( 'Should include current post when exclude_current is false', async ( {
+		page,
+		editor,
+		admin,
+	} ) => {
+		// Create test posts
+		const postTitles = [ 'Test Post One', 'Test Post Two' ];
+
+		for ( const title of postTitles ) {
+			await admin.createNewPost( { title } );
+			await editor.publishPost();
+		}
+
+		// Create main post with AQL block
+		await admin.createNewPost( { title: 'Main Post Without Exclusion' } );
+
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+			fullscreenMode: false,
+		} );
+
+		// Insert AQL block
+		await insertAQL( { editor, page } );
+
+		// Do NOT enable "Exclude Current Post" - leave it unchecked
+
+		// Verify it's NOT checked
+		await expect(
+			page.getByRole( 'checkbox', { name: 'Exclude Current Post' } )
+		).not.toBeChecked();
+
+		// Publish the post
+		await editor.publishPost();
+
+		// Get the post URL
+		const postUrl = await page
+			.locator( '.post-publish-panel__postpublish-buttons a' )
+			.first()
+			.getAttribute( 'href' );
+
+		expect( postUrl ).toBeTruthy();
+
+		// Navigate to frontend
+		await page.goto( postUrl! );
+		await page.waitForLoadState( 'networkidle' );
+
+		// Get all post titles in the query loop
+		const postLinksInLoop = page.locator(
+			'.wp-block-query .wp-block-post-title a'
+		);
+
+		await expect( postLinksInLoop.first() ).toBeVisible();
+
+		const displayedTitles = await postLinksInLoop.allTextContents();
+
+		// Verify "Main Post Without Exclusion" IS in the displayed titles
+		expect( displayedTitles ).toContain( 'Main Post Without Exclusion' );
+
+		// Verify test posts are also displayed
+		expect( displayedTitles ).toContain( 'Test Post One' );
+		expect( displayedTitles ).toContain( 'Test Post Two' );
+	} );
+
+	test( 'Should work correctly when toggled on then off', async ( {
+		page,
+		editor,
+		admin,
+	} ) => {
+		// Create test posts
+		await admin.createNewPost( { title: 'Another Test Post' } );
+		await editor.publishPost();
+
+		// Create main post
+		await admin.createNewPost( { title: 'Toggle Test Post' } );
+
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+			fullscreenMode: false,
+		} );
+
+		// Insert AQL block
+		await insertAQL( { editor, page } );
+
+		// Toggle ON
+		await page
+			.getByRole( 'checkbox', { name: 'Exclude Current Post' } )
+			.click();
+
+		// Toggle OFF
+		await page
+			.getByRole( 'checkbox', { name: 'Exclude Current Post' } )
+			.click();
+
+		// Verify it's unchecked
+		await expect(
+			page.getByRole( 'checkbox', { name: 'Exclude Current Post' } )
+		).not.toBeChecked();
+
+		// Publish
+		await editor.publishPost();
+
+		// Get URL and navigate to frontend
+		const postUrl = await page
+			.locator( '.post-publish-panel__postpublish-buttons a' )
+			.first()
+			.getAttribute( 'href' );
+
+		await page.goto( postUrl! );
+		await page.waitForLoadState( 'networkidle' );
+
+		// Get displayed titles
+		const postLinksInLoop = page.locator(
+			'.wp-block-query .wp-block-post-title a'
+		);
+
+		await expect( postLinksInLoop.first() ).toBeVisible();
+
+		const displayedTitles = await postLinksInLoop.allTextContents();
+
+		// Since exclude_current is OFF, the post should be included
+		expect( displayedTitles ).toContain( 'Toggle Test Post' );
+	} );
+} );

--- a/tests/e2e/tests/exclude-current-post.spec.ts
+++ b/tests/e2e/tests/exclude-current-post.spec.ts
@@ -171,13 +171,11 @@ test.describe( 'Exclude Current Post - Frontend Rendering', () => {
 		editor,
 		admin,
 	} ) => {
-		// Create test posts
-		const postTitles = [ 'Test Post One', 'Test Post Two' ];
+		test.setTimeout( 60000 );
 
-		for ( const title of postTitles ) {
-			await admin.createNewPost( { title } );
-			await editor.publishPost();
-		}
+		// Create one test post - enough to verify inclusion without slowing CI.
+		await admin.createNewPost( { title: 'Test Post One' } );
+		await editor.publishPost();
 
 		// Create main post with AQL block
 		await admin.createNewPost( { title: 'Main Post Without Exclusion' } );
@@ -224,9 +222,8 @@ test.describe( 'Exclude Current Post - Frontend Rendering', () => {
 		// Verify "Main Post Without Exclusion" IS in the displayed titles
 		expect( displayedTitles ).toContain( 'Main Post Without Exclusion' );
 
-		// Verify test posts are also displayed
+		// Verify test post is also displayed
 		expect( displayedTitles ).toContain( 'Test Post One' );
-		expect( displayedTitles ).toContain( 'Test Post Two' );
 	} );
 
 	test( 'Should work correctly when toggled on then off', async ( {
@@ -234,6 +231,8 @@ test.describe( 'Exclude Current Post - Frontend Rendering', () => {
 		editor,
 		admin,
 	} ) => {
+		test.setTimeout( 60000 );
+
 		// Create test posts
 		await admin.createNewPost( { title: 'Another Test Post' } );
 		await editor.publishPost();

--- a/tests/e2e/tests/exclude-current-post.spec.ts
+++ b/tests/e2e/tests/exclude-current-post.spec.ts
@@ -156,57 +156,20 @@ test.describe( 'Exclude Current Post - Frontend Rendering', () => {
 		// Wait for the page to load
 		await page.waitForLoadState( 'networkidle' );
 
-		// Save screenshot for debugging
-		await page.screenshot( {
-			path: 'test-results/frontend-page.png',
-			fullPage: true,
-		} );
+		// The AQL block is the first query loop inserted into the post content.
+		// The theme may also render its own query loops (e.g. a "More posts"
+		// section), so we scope to the first .wp-block-query to isolate our block.
+		const aqlQueryLoop = page.locator( '.wp-block-query' ).first();
+		await expect( aqlQueryLoop ).toBeVisible();
 
-		// Check if there are ANY query loops on the page
-		const allQueryLoops = page.locator( '.wp-block-query' );
-		const queryLoopCount = await allQueryLoops.count();
+		const postTitlesInAQL = aqlQueryLoop.locator( '.wp-block-post-title' );
+		const aqlTitles = await postTitlesInAQL.allTextContents();
 
-		// If no query loops found, the block might not be rendering
-		if ( queryLoopCount === 0 ) {
-			await page.content();
-		}
+		// The AQL block should NOT include the current post in its results.
+		expect( aqlTitles ).not.toContain( 'Main Post with AQL' );
 
-		// Just check ALL post links on the page for now
-		const allPostLinks = page.locator( '.wp-block-post-title a' );
-		const postLinkCount = await allPostLinks.count();
-
-		// Verify we have posts displayed
-		if ( postLinkCount === 0 ) {
-			throw new Error( 'No post links found on the page' );
-		}
-
-		await expect( allPostLinks.first() ).toBeVisible();
-
-		// Get the text content of all displayed post titles
-		const displayedTitles = await allPostLinks.allTextContents();
-
-		// TEMPORARY: Since we can't reliably distinguish between theme query loops
-		// and our AQL block, we're going to mark this as a known limitation
-		// and adjust our test expectations
-
-		// The theme's query loop will show ALL posts
-		// Our AQL block should NOT show the current post
-		// But we can't easily tell them apart in the rendered HTML
-
-		// For now, let's verify that our AQL-specific functionality works
-		// by checking if MOST occurrences exclude the current post
-
-		// Count occurrences of each post title
-		const mainPostCount = displayedTitles.filter(
-			( t ) => t === 'Main Post with AQL'
-		).length;
-		const alphaCount = displayedTitles.filter(
-			( t ) => t === 'Test Post Alpha'
-		).length;
-
-		// The test posts should appear more frequently than the main post
-		// because the AQL block should exclude the main post
-		expect( mainPostCount ).toBeLessThan( alphaCount );
+		// Other posts should still appear.
+		expect( aqlTitles ).toContain( 'Test Post Alpha' );
 	} );
 
 	test( 'Should include current post when exclude_current is false', async ( {

--- a/tests/e2e/tests/exclude-current-post.spec.ts
+++ b/tests/e2e/tests/exclude-current-post.spec.ts
@@ -42,9 +42,7 @@ test.describe( 'Exclude Current Post', () => {
 
 		const blocks = await editor.getBlocks();
 
-		expect(
-			blocks[ 0 ].attributes.query.exclude_current
-		).toBeUndefined();
+		expect( blocks[ 0 ].attributes.query.exclude_current ).toBeUndefined();
 	} );
 
 	test( 'Should toggle on and store true', async ( { page, editor } ) => {
@@ -60,9 +58,7 @@ test.describe( 'Exclude Current Post', () => {
 
 		const blocks = await editor.getBlocks();
 
-		expect( blocks[ 0 ].attributes.query.exclude_current ).toEqual(
-			true
-		);
+		expect( blocks[ 0 ].attributes.query.exclude_current ).toEqual( true );
 	} );
 
 	test( 'Should toggle off and store false', async ( { page, editor } ) => {
@@ -84,9 +80,7 @@ test.describe( 'Exclude Current Post', () => {
 
 		const blocks = await editor.getBlocks();
 
-		expect( blocks[ 0 ].attributes.query.exclude_current ).toEqual(
-			false
-		);
+		expect( blocks[ 0 ].attributes.query.exclude_current ).toEqual( false );
 	} );
 
 	test( 'Should not be disabled in a regular post', async ( { page } ) => {
@@ -163,25 +157,23 @@ test.describe( 'Exclude Current Post - Frontend Rendering', () => {
 		await page.waitForLoadState( 'networkidle' );
 
 		// Save screenshot for debugging
-		await page.screenshot( { path: 'test-results/frontend-page.png', fullPage: true } );
+		await page.screenshot( {
+			path: 'test-results/frontend-page.png',
+			fullPage: true,
+		} );
 
 		// Check if there are ANY query loops on the page
 		const allQueryLoops = page.locator( '.wp-block-query' );
 		const queryLoopCount = await allQueryLoops.count();
-		console.log( `Found ${ queryLoopCount } query loop(s) on the page` );
 
 		// If no query loops found, the block might not be rendering
 		if ( queryLoopCount === 0 ) {
-			console.log( 'No query loops found! Block may not be rendering.' );
-			// Save HTML for inspection
-			const html = await page.content();
-			console.log( 'Page HTML sample:', html.substring( 0, 1000 ) );
+			await page.content();
 		}
 
 		// Just check ALL post links on the page for now
 		const allPostLinks = page.locator( '.wp-block-post-title a' );
 		const postLinkCount = await allPostLinks.count();
-		console.log( `Found ${ postLinkCount } post link(s) on the page` );
 
 		// Verify we have posts displayed
 		if ( postLinkCount === 0 ) {
@@ -192,8 +184,6 @@ test.describe( 'Exclude Current Post - Frontend Rendering', () => {
 
 		// Get the text content of all displayed post titles
 		const displayedTitles = await allPostLinks.allTextContents();
-
-		console.log( 'All displayed post titles:', displayedTitles );
 
 		// TEMPORARY: Since we can't reliably distinguish between theme query loops
 		// and our AQL block, we're going to mark this as a known limitation
@@ -207,11 +197,12 @@ test.describe( 'Exclude Current Post - Frontend Rendering', () => {
 		// by checking if MOST occurrences exclude the current post
 
 		// Count occurrences of each post title
-		const mainPostCount = displayedTitles.filter( t => t === 'Main Post with AQL' ).length;
-		const alphaCount = displayedTitles.filter( t => t === 'Test Post Alpha' ).length;
-
-		console.log( `"Main Post with AQL" appears ${ mainPostCount } time(s)` );
-		console.log( `"Test Post Alpha" appears ${ alphaCount } time(s)` );
+		const mainPostCount = displayedTitles.filter(
+			( t ) => t === 'Main Post with AQL'
+		).length;
+		const alphaCount = displayedTitles.filter(
+			( t ) => t === 'Test Post Alpha'
+		).length;
 
 		// The test posts should appear more frequently than the main post
 		// because the AQL block should exclude the main post


### PR DESCRIPTION
This PR changes the logic around how the exclude current post works. Rather than saving the post id, it stores a boolean and the appropriate Id is determined dynamically. This should address the control not working in Synced Patterns and templates in some cases.

Closes #149 , #123

Related support topics:
 * https://wordpress.org/support/topic/exclude-current-post-doesnt-work-if-aql-is-inside-a-pattern/
 * https://wordpress.org/support/topic/exclude-current-post-not-working-in-template-part/