### PR TITLE
Fix and improve caching controls

### DIFF
--- a/includes/query-loop.php
+++ b/includes/query-loop.php
@@ -179,6 +179,8 @@ add_filter(
 
 		if ( ! $query->is_admin &&
 			isset( $query->query['is_aql'] ) &&
+			isset( $query->query['enable_caching'] ) &&
+			true === $query->query['enable_caching'] &&
 			! isset( $_GET['context'] ) && // phpcs:ignore
 			! isset( $_GET['canvas'] ) // phpcs:ignore
 		) {
@@ -204,6 +206,8 @@ add_filter(
 	function ( $posts, $query ) {
 		if ( ! $query->is_admin &&
 			isset( $query->query['is_aql'] ) &&
+			isset( $query->query['enable_caching'] ) &&
+			true === $query->query['enable_caching'] &&
 			! isset( $_GET['context'] ) && // phpcs:ignore
 			! isset( $_GET['canvas'] ) // phpcs:ignore
 		) {

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ Improve the performance of the query by disabling pagination.
 
 #### Enable Caching
 
-Store query results in a transient for one hour to reduce database load on subsequent page loads. Caching is disabled automatically when the order is set to Random. Found in the **AQL: Performance Controls** panel.
+Store query results in a transient for one hour to reduce database load on subsequent page loads. The caching toggle is unavailable when the order is set to Random, and switching to Random order will clear any existing caching setting. Found in the **AQL: Performance Controls** panel.
 
 ## Filtering the available controls
 

--- a/readme.md
+++ b/readme.md
@@ -65,7 +65,11 @@ Sort in ascending or descending order by:
 
 #### Disable Pagination
 
-Improve the performance of the query by disabling pagination. This is done automatically when there is now Pagination block in teh Post Template.
+Improve the performance of the query by disabling pagination.
+
+#### Enable Caching
+
+Store query results in a transient for one hour to reduce database load on subsequent page loads. Caching is disabled automatically when the order is set to Random. Found in the **AQL: Performance Controls** panel.
 
 ## Filtering the available controls
 
@@ -103,6 +107,7 @@ add_filter(
 -   `'date_query_dynamic_range'`
 -   `'date_query_relationship'`
 -   `'pagination'`
+-   `'enable_caching'`
 
 ## Extending AQL
 

--- a/readme.txt
+++ b/readme.txt
@@ -86,9 +86,9 @@ Sort your content exactly how you want:
 
 ==== ⚡ Performance Optimization ====
 
-* **Smart pagination**: Automatically disable pagination when not needed
+* **Disable pagination**: Reduce query overhead by turning off pagination when it is not needed
+* **Enable caching**: Store query results in a transient for one hour to reduce database load on subsequent page loads. Automatically disabled when the order is set to Random
 * **Efficient queries**: Optimized database queries for better performance
-* **Caching friendly**: Works seamlessly with popular caching plugins
 
 === Customization & Extensibility ===
 
@@ -116,11 +116,13 @@ add_filter(
 * `'post_meta_query'` - Meta field queries
 * `'post_order'` - Sorting options
 * `'exclude_current_post'` - Current post exclusion
+* `'exclude_posts'` - Exclude a curated list of posts
 * `'include_posts'` - Manual post inclusion
 * `'child_items_only'` - Child post filtering
 * `'date_query_dynamic_range'` - Date range queries
 * `'date_query_relationship'` - Date query logic
 * `'pagination'` - Pagination controls
+* `'enable_caching'` - Query result caching
 
 ==== Developer-Friendly ====
 

--- a/readme.txt
+++ b/readme.txt
@@ -87,7 +87,7 @@ Sort your content exactly how you want:
 ==== ⚡ Performance Optimization ====
 
 * **Disable pagination**: Reduce query overhead by turning off pagination when it is not needed
-* **Enable caching**: Store query results in a transient for one hour to reduce database load on subsequent page loads. Automatically disabled when the order is set to Random
+* **Enable caching**: Store query results in a transient for one hour to reduce database load on subsequent page loads. The caching toggle is unavailable when the order is set to Random, and switching to Random order will clear any existing caching setting
 * **Efficient queries**: Optimized database queries for better performance
 
 === Customization & Extensibility ===

--- a/src/components/performance-controls.js
+++ b/src/components/performance-controls.js
@@ -11,17 +11,33 @@ import {
 
 import { __ } from '@wordpress/i18n';
 
-export const PerformanceControls = ( { attributes, setAttributes } ) => {
+export const PerformanceControls = ( {
+	attributes,
+	setAttributes,
+	allowedControls,
+} ) => {
 	const { query: { enable_caching: enableCaching, orderBy } = {} } =
 		attributes;
+
+	if ( ! allowedControls.includes( 'enable_caching' ) ) {
+		return null;
+	}
+
 	return (
 		<ToolsPanel
-			label={ __( 'AQL: Performance Controls' ) }
-			resetAll={ () => {} }
+			label={ __( 'AQL: Performance Controls', 'advanced-query-loop' ) }
+			resetAll={ () =>
+				setAttributes( {
+					query: {
+						...attributes.query,
+						enable_caching: false,
+					},
+				} )
+			}
 		>
 			<ToolsPanelItem
 				hasValue={ () => !! enableCaching }
-				label={ __( 'Caching' ) }
+				label={ __( 'Caching', 'advanced-query-loop' ) }
 				onDeselect={ () =>
 					setAttributes( {
 						query: {

--- a/src/components/post-order-controls.js
+++ b/src/components/post-order-controls.js
@@ -94,6 +94,9 @@ export const PostOrderControls = ( {
 						query: {
 							...attributes.query,
 							orderBy: newOrderBy,
+							...( newOrderBy === 'rand' && {
+								enable_caching: false,
+							} ),
 						},
 					} );
 				} }

--- a/tests/e2e/tests/enable-caching.spec.ts
+++ b/tests/e2e/tests/enable-caching.spec.ts
@@ -11,6 +11,8 @@ import { insertAQL } from '../utils';
 /**
  * Opens the AQL Performance Controls panel options menu and selects
  * the Caching item so the toggle becomes visible in the panel.
+ *
+ * @param {import('@playwright/test').Page} page Playwright page object.
  */
 const addCachingControl = async ( page ) => {
 	await page
@@ -120,7 +122,9 @@ test.describe( 'Enable Caching toggle', () => {
 
 		// Use the panel's Reset All option.
 		await page
-			.getByRole( 'button', { name: 'AQL: Performance Controls options' } )
+			.getByRole( 'button', {
+				name: 'AQL: Performance Controls options',
+			} )
 			.click();
 		await page.getByRole( 'menuitem', { name: 'Reset all' } ).click();
 
@@ -254,7 +258,9 @@ test.describe( 'Enable Caching - Frontend Rendering', () => {
 		// The query loop should render with posts visible.
 		const queryLoop = page.locator( '.wp-block-query' ).first();
 		await expect( queryLoop ).toBeVisible();
-		await expect( queryLoop.locator( '.wp-block-post-title' ).first() ).toBeVisible();
+		await expect(
+			queryLoop.locator( '.wp-block-post-title' ).first()
+		).toBeVisible();
 	} );
 
 	test( 'Repeated loads of a cached page return consistent results', async ( {

--- a/tests/e2e/tests/enable-caching.spec.ts
+++ b/tests/e2e/tests/enable-caching.spec.ts
@@ -1,0 +1,310 @@
+/**
+ * Import our custom test fixtures.
+ */
+import { test, expect } from '../aql-fixtures';
+
+/**
+ * Internal dependencies.
+ */
+import { insertAQL } from '../utils';
+
+/**
+ * Opens the AQL Performance Controls panel options menu and selects
+ * the Caching item so the toggle becomes visible in the panel.
+ */
+const addCachingControl = async ( page ) => {
+	await page
+		.getByRole( 'button', { name: 'AQL: Performance Controls options' } )
+		.click();
+	await page.getByRole( 'menuitemcheckbox', { name: 'Caching' } ).click();
+	await page.keyboard.press( 'Escape' );
+};
+
+test.describe( 'Enable Caching toggle', () => {
+	test.beforeEach( async ( { page, editor, playground, admin } ) => {
+		await playground.init( { page, editor } );
+		await admin.visitAdminPage( 'post-new.php' );
+
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+			fullscreenMode: false,
+		} );
+		await insertAQL( { editor, page } );
+	} );
+
+	test.afterEach( async ( { playground } ) => {
+		await playground.cleanUp();
+	} );
+
+	test( 'AQL: Performance Controls panel is visible', async ( { page } ) => {
+		await expect(
+			page.getByText( 'AQL: Performance Controls' )
+		).toBeVisible();
+	} );
+
+	test( 'Caching control can be added from the panel options menu', async ( {
+		page,
+	} ) => {
+		await addCachingControl( page );
+
+		await expect(
+			page.getByRole( 'checkbox', {
+				name: 'Enable Caching for this query',
+			} )
+		).toBeVisible();
+
+		await expect(
+			page.getByRole( 'checkbox', {
+				name: 'Enable Caching for this query',
+			} )
+		).not.toBeChecked();
+	} );
+
+	test( 'Enabling caching sets the attribute to true', async ( {
+		page,
+		editor,
+	} ) => {
+		await addCachingControl( page );
+
+		await page
+			.getByRole( 'checkbox', { name: 'Enable Caching for this query' } )
+			.click();
+
+		await expect(
+			page.getByRole( 'checkbox', {
+				name: 'Enable Caching for this query',
+			} )
+		).toBeChecked();
+
+		const blocks = await editor.getBlocks();
+		expect( blocks[ 0 ].attributes.query.enable_caching ).toEqual( true );
+	} );
+
+	test( 'Disabling caching sets the attribute to false', async ( {
+		page,
+		editor,
+	} ) => {
+		await addCachingControl( page );
+
+		// Toggle on then off.
+		await page
+			.getByRole( 'checkbox', { name: 'Enable Caching for this query' } )
+			.click();
+		await page
+			.getByRole( 'checkbox', { name: 'Enable Caching for this query' } )
+			.click();
+
+		await expect(
+			page.getByRole( 'checkbox', {
+				name: 'Enable Caching for this query',
+			} )
+		).not.toBeChecked();
+
+		const blocks = await editor.getBlocks();
+		expect( blocks[ 0 ].attributes.query.enable_caching ).toEqual( false );
+	} );
+
+	test( 'Reset All clears the enable_caching attribute', async ( {
+		page,
+		editor,
+	} ) => {
+		await addCachingControl( page );
+
+		// Enable caching.
+		await page
+			.getByRole( 'checkbox', { name: 'Enable Caching for this query' } )
+			.click();
+
+		let blocks = await editor.getBlocks();
+		expect( blocks[ 0 ].attributes.query.enable_caching ).toEqual( true );
+
+		// Use the panel's Reset All option.
+		await page
+			.getByRole( 'button', { name: 'AQL: Performance Controls options' } )
+			.click();
+		await page.getByRole( 'menuitem', { name: 'Reset all' } ).click();
+
+		blocks = await editor.getBlocks();
+		expect( blocks[ 0 ].attributes.query.enable_caching ).toEqual( false );
+	} );
+
+	test( 'Caching toggle is disabled when order is set to Random', async ( {
+		page,
+	} ) => {
+		await addCachingControl( page );
+
+		await page.getByLabel( 'Post Order By' ).selectOption( 'rand' );
+
+		await expect(
+			page.getByRole( 'checkbox', {
+				name: 'Enable Caching for this query',
+			} )
+		).toBeDisabled();
+	} );
+
+	test( 'Switching to Random order clears enable_caching', async ( {
+		page,
+		editor,
+	} ) => {
+		await addCachingControl( page );
+
+		// Enable caching first.
+		await page
+			.getByRole( 'checkbox', { name: 'Enable Caching for this query' } )
+			.click();
+
+		let blocks = await editor.getBlocks();
+		expect( blocks[ 0 ].attributes.query.enable_caching ).toEqual( true );
+
+		// Switch to Random order.
+		await page.getByLabel( 'Post Order By' ).selectOption( 'rand' );
+
+		// Attribute must be cleared.
+		blocks = await editor.getBlocks();
+		expect( blocks[ 0 ].attributes.query.enable_caching ).toEqual( false );
+
+		// Toggle must be disabled.
+		await expect(
+			page.getByRole( 'checkbox', {
+				name: 'Enable Caching for this query',
+			} )
+		).toBeDisabled();
+	} );
+
+	test( 'Switching away from Random order re-enables the caching toggle', async ( {
+		page,
+	} ) => {
+		await addCachingControl( page );
+
+		// Go to Random first.
+		await page.getByLabel( 'Post Order By' ).selectOption( 'rand' );
+
+		await expect(
+			page.getByRole( 'checkbox', {
+				name: 'Enable Caching for this query',
+			} )
+		).toBeDisabled();
+
+		// Switch to a non-random order.
+		await page.getByLabel( 'Post Order By' ).selectOption( 'date' );
+
+		await expect(
+			page.getByRole( 'checkbox', {
+				name: 'Enable Caching for this query',
+			} )
+		).toBeEnabled();
+
+		await expect(
+			page.getByRole( 'checkbox', {
+				name: 'Enable Caching for this query',
+			} )
+		).not.toBeChecked();
+	} );
+} );
+
+test.describe( 'Enable Caching - Frontend Rendering', () => {
+	test.beforeEach( async ( { page, editor, playground } ) => {
+		await playground.init( { page, editor } );
+	} );
+
+	test.afterEach( async ( { playground } ) => {
+		await playground.cleanUp();
+	} );
+
+	test( 'Page renders correctly with caching enabled', async ( {
+		page,
+		editor,
+		admin,
+	} ) => {
+		test.setTimeout( 60000 );
+
+		await admin.visitAdminPage( 'post-new.php' );
+
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+			fullscreenMode: false,
+		} );
+
+		await insertAQL( { editor, page } );
+
+		await addCachingControl( page );
+
+		await page
+			.getByRole( 'checkbox', { name: 'Enable Caching for this query' } )
+			.click();
+
+		await expect(
+			page.getByRole( 'checkbox', {
+				name: 'Enable Caching for this query',
+			} )
+		).toBeChecked();
+
+		await editor.publishPost();
+
+		const postUrl = await page
+			.locator( '.post-publish-panel__postpublish-buttons a' )
+			.first()
+			.getAttribute( 'href' );
+
+		expect( postUrl ).toBeTruthy();
+
+		await page.goto( postUrl! );
+		await page.waitForLoadState( 'networkidle' );
+
+		// The query loop should render with posts visible.
+		const queryLoop = page.locator( '.wp-block-query' ).first();
+		await expect( queryLoop ).toBeVisible();
+		await expect( queryLoop.locator( '.wp-block-post-title' ).first() ).toBeVisible();
+	} );
+
+	test( 'Repeated loads of a cached page return consistent results', async ( {
+		page,
+		editor,
+		admin,
+	} ) => {
+		test.setTimeout( 60000 );
+
+		await admin.visitAdminPage( 'post-new.php' );
+
+		await editor.setPreferences( 'core/edit-post', {
+			welcomeGuide: false,
+			fullscreenMode: false,
+		} );
+
+		await insertAQL( { editor, page } );
+		await addCachingControl( page );
+
+		await page
+			.getByRole( 'checkbox', { name: 'Enable Caching for this query' } )
+			.click();
+
+		await editor.publishPost();
+
+		const postUrl = await page
+			.locator( '.post-publish-panel__postpublish-buttons a' )
+			.first()
+			.getAttribute( 'href' );
+
+		expect( postUrl ).toBeTruthy();
+
+		// First visit primes the cache.
+		await page.goto( postUrl! );
+		await page.waitForLoadState( 'networkidle' );
+
+		const firstLoadTitles = await page
+			.locator( '.wp-block-query .wp-block-post-title' )
+			.allTextContents();
+
+		// Second visit should serve from cache.
+		await page.goto( postUrl! );
+		await page.waitForLoadState( 'networkidle' );
+
+		const secondLoadTitles = await page
+			.locator( '.wp-block-query .wp-block-post-title' )
+			.allTextContents();
+
+		// Both loads must return the same posts in the same order.
+		expect( secondLoadTitles ).toEqual( firstLoadTitles );
+		expect( firstLoadTitles.length ).toBeGreaterThan( 0 );
+	} );
+} );

--- a/tests/unit/Enable_Caching_Tests.php
+++ b/tests/unit/Enable_Caching_Tests.php
@@ -217,6 +217,86 @@ class Enable_Caching_Tests extends TestCase {
 	}
 
 	/**
+	 * Test that only boolean true satisfies the strict filter check.
+	 *
+	 * The posts_pre_query and the_posts filters use `true === $query->query['enable_caching']`.
+	 * Only PHP boolean true passes this check; truthy values like 1, "1", or "true" do not.
+	 */
+	public function test_boolean_true_stored_with_strict_equality() {
+		$qpg = new Query_Params_Generator( array(), array( 'enable_caching' => true ) );
+		$qpg->process_all();
+
+		$result = $qpg->get_query_args();
+
+		// assertSame enforces type — only true (boolean) satisfies the filter's `true ===` check.
+		$this->assertSame( true, $result['enable_caching'] );
+	}
+
+	/**
+	 * Test that truthy non-boolean values are stored by the trait but won't trigger caching.
+	 *
+	 * The caching filters use a strict `true ===` comparison, so values like 1, "1", and "true"
+	 * will be present in query args but will not satisfy the filter condition.
+	 */
+	public function test_truthy_non_boolean_values_will_not_satisfy_filter() {
+		$non_boolean_truthy = array( 1, '1', 'true' );
+
+		foreach ( $non_boolean_truthy as $value ) {
+			$qpg = new Query_Params_Generator( array(), array( 'enable_caching' => $value ) );
+			$qpg->process_all();
+
+			$result = $qpg->get_query_args();
+
+			// The value is stored in args by the trait...
+			$this->assertArrayHasKey( 'enable_caching', $result );
+
+			// ...but it does NOT satisfy the strict `true ===` filter condition.
+			$this->assertNotSame( true, $result['enable_caching'] );
+		}
+	}
+
+	/**
+	 * Test that disabling caching removes the key entirely from query args.
+	 *
+	 * The caching filters check isset() first, so the key must be absent (not merely
+	 * falsy) for the isset() guard to correctly short-circuit and skip caching.
+	 */
+	public function test_false_caching_key_is_absent_not_just_falsy() {
+		$qpg = new Query_Params_Generator( array(), array( 'enable_caching' => false ) );
+		$qpg->process_all();
+
+		$result = $qpg->get_query_args();
+
+		// Key must be absent so that isset( $query->query['enable_caching'] ) returns false.
+		$this->assertArrayNotHasKey( 'enable_caching', $result );
+
+		// is_aql must still be present (the first condition the filters check).
+		$this->assertArrayHasKey( 'is_aql', $result );
+		$this->assertSame( true, $result['is_aql'] );
+	}
+
+	/**
+	 * Test that both conditions required by the caching filters are satisfied together.
+	 *
+	 * The filters check: is_aql is set AND enable_caching === true.
+	 * Both must be present for caching to be triggered.
+	 */
+	public function test_both_filter_conditions_met_when_caching_enabled() {
+		$qpg = new Query_Params_Generator( array(), array( 'enable_caching' => true ) );
+		$qpg->process_all();
+
+		$result = $qpg->get_query_args();
+
+		// Condition 1: isset( $query->query['is_aql'] )
+		$this->assertArrayHasKey( 'is_aql', $result );
+		$this->assertSame( true, $result['is_aql'] );
+
+		// Condition 2: true === $query->query['enable_caching']
+		$this->assertArrayHasKey( 'enable_caching', $result );
+		$this->assertSame( true, $result['enable_caching'] );
+	}
+
+	/**
 	 * Test enable_caching and disable_pagination can work together
 	 */
 	public function test_caching_with_pagination_disabled() {


### PR DESCRIPTION
## Summary

- Fixes a bug where `posts_pre_query` and `the_posts` filters would attempt to cache/serve results for **any** AQL query, even when the Enable Caching toggle was off
- Adds an `allowedControls` guard to `PerformanceControls` so the panel respects the `aql_allowed_controls` filter like every other control
- Fixes `resetAll` in the Performance Controls panel — it was a no-op and now correctly sets `enable_caching` to `false`
- Fixes `enable_caching` being left set when switching `orderBy` to `Random` — switching to Random now atomically clears the attribute
- Adds missing `'advanced-query-loop'` text domain to i18n strings in `performance-controls.js`
- Fixes minor whitespace inconsistency in the PHP filter conditions
- Updates both `readme.md` and `readme.txt` to document the Enable Caching and Disable Pagination controls and complete the control identifier lists (`exclude_posts` and `enable_caching` were missing from `readme.txt`)
- Adds PHP unit tests explicitly documenting the strict `true ===` filter contract
- Adds 10 e2e tests covering editor UI behaviour and frontend rendering with caching enabled

## Test plan

- [ ] Enable caching toggle appears in the AQL: Performance Controls panel (via the panel options menu)
- [ ] Toggling on sets `enable_caching: true` in block attributes; toggling off sets it to `false`
- [ ] Reset All in the Performance Controls panel clears `enable_caching`
- [ ] Selecting Random order disables the caching toggle
- [ ] Switching to Random order clears an existing `enable_caching: true` attribute
- [ ] Switching away from Random re-enables the toggle
- [ ] Frontend renders correctly with caching enabled; repeated loads return consistent results
- [ ] `npm run test:unit` passes
- [ ] `npm run test:e2e` passes (or run `npx playwright test tests/e2e/tests/enable-caching.spec.ts` to run only the new tests)