### PR TITLE
Fix TypeError crash when window.aql.allowedControls is undefined

### DIFF
--- a/includes/enqueues.php
+++ b/includes/enqueues.php
@@ -40,7 +40,7 @@ if ( ! function_exists( 'add_action' ) ) {
 			// Add inline script.
 			wp_add_inline_script(
 				'advanced-query-loop',
-				'aql.allowedControls = "' . implode( ',', Query_Params_Generator::get_allowed_controls() ) . '";'
+				'window.aql = window.aql || {}; window.aql.allowedControls = "' . implode( ',', Query_Params_Generator::get_allowed_controls() ) . '";'
 			);
 		}
 

--- a/src/variations/controls.js
+++ b/src/variations/controls.js
@@ -46,6 +46,25 @@ const isAdvancedQueryLoop = ( props ) => {
 };
 
 /**
+ * Fallback list of all control identifiers, used when window.aql.allowedControls
+ * is not available (e.g. due to script loading order issues from caching plugins).
+ */
+const ALL_CONTROLS = [
+	'additional_post_types',
+	'taxonomy_query_builder',
+	'post_meta_query',
+	'post_order',
+	'exclude_current_post',
+	'include_posts',
+	'child_items_only',
+	'date_query_dynamic_range',
+	'date_query_relationship',
+	'pagination',
+	'exclude_posts',
+	'enable_caching',
+];
+
+/**
  * Custom controls
  *
  * @param {*} BlockEdit
@@ -71,9 +90,10 @@ const withAdvancedQueryControls = ( BlockEdit ) => ( props ) => {
 
 	// If the is the correct variation, add the custom controls.
 	if ( isAdvancedQueryLoop( props ) ) {
-		const { allowedControls } = window?.aql;
+		const { allowedControls } = window?.aql ?? {};
 		const { attributes } = props;
-		const allowedControlsArray = allowedControls.split( ',' );
+		const allowedControlsArray =
+			allowedControls?.split( ',' ) ?? ALL_CONTROLS;
 		const propsWithControls = {
 			...props,
 			allowedControls: allowedControlsArray,


### PR DESCRIPTION
## Summary

Fixes a `TypeError: Cannot read properties of undefined (reading 'split')` crash reported in #144 and #138.

- **Root cause**: `window.aql.allowedControls` is `undefined` when `controls.js` tries to call `.split(',')` on it. Most likely triggered by caching/optimization plugins (e.g. WP Rocket, W3 Total Cache) that reorder script loading, causing the PHP inline script to execute before `window.aql` is initialized by the main bundle.
- PHP inline script now safely initializes `window.aql` before setting `allowedControls`, preventing a ReferenceError if the inline script runs out of order
- JS now uses optional chaining with an `ALL_CONTROLS` fallback so controls still render when `allowedControls` is unavailable, rather than crashing or silently hiding all controls

## Changes

- `includes/enqueues.php` — Changed `aql.allowedControls = "..."` to `window.aql = window.aql || {}; window.aql.allowedControls = "..."` so `window.aql` is safely initialized regardless of script load order
- `src/variations/controls.js` — Added `?? {}` to the `window?.aql` destructure and `?? ALL_CONTROLS` fallback on `.split()` so the editor never crashes even if the inline script fails to run

## Test plan

- [ ] Install a script optimization plugin (e.g. WP Rocket or Autoptimize) and confirm no TypeError in the block editor console when using an AQL block
- [ ] Confirm all AQL controls still appear normally without any optimization plugin active
- [ ] Confirm the `aql_allowed_controls` PHP filter still correctly restricts visible controls

Closes #144
Closes #138