### PR TITLE
Meta query date functions

### DIFF
--- a/includes/Traits/Meta_Query.php
+++ b/includes/Traits/Meta_Query.php
@@ -20,6 +20,10 @@ trait Meta_Query {
 
 			if ( isset( $meta_query_data['queries'] ) ) {
 				foreach ( $meta_query_data['queries'] as $query ) {
+					if ( in_array( $query['meta_type'] ?? '', [ 'DATETIME', 'DATE', 'TIME' ], true ) ) {
+						$query['meta_value'] = $this->map_date_functions( $query['meta_value'] ?? '' );
+					}
+					
 					$meta_queries[] = array_filter(
 						array(
 							'key'     => $query['meta_key'] ?? '',
@@ -33,5 +37,36 @@ trait Meta_Query {
 		}
 
 		return array_filter( $meta_queries );
+	}
+
+	/**
+	 * Enable a selection of dynamic date functions for meta queries.
+	 *
+	 * @param string $value Argument to be passed to WP_Meta_Query.
+	 */
+	protected function map_date_functions( $value ) {
+		$value = str_ireplace(
+			[
+				'NOW()',
+				'HOUR()',
+				'DAY()',
+				'MONTH()',
+				'YEAR()',
+				'WEEK()',
+				'UNIX_TIMESTAMP()',
+			],
+			[
+				current_time( 'Y-m-d H:i:s' ),
+				intval( date( 'H' ) ),
+				intval( date( 'd' ) ),
+				intval( date( 'm' ) ),
+				intval( date( 'Y' ) ),
+				intval( date( 'W' ) ),
+				time(),
+			],
+			$value
+		);
+	
+		return $value;
 	}
 }

--- a/includes/Traits/Meta_Query.php
+++ b/includes/Traits/Meta_Query.php
@@ -20,14 +20,10 @@ trait Meta_Query {
 
 			if ( isset( $meta_query_data['queries'] ) ) {
 				foreach ( $meta_query_data['queries'] as $query ) {
-					if ( in_array( $query['meta_type'] ?? '', [ 'DATETIME', 'DATE', 'TIME' ], true ) ) {
-						$query['meta_value'] = $this->map_date_functions( $query['meta_value'] ?? '' );
-					}
-					
 					$meta_queries[] = array_filter(
 						array(
 							'key'     => $query['meta_key'] ?? '',
-							'value'   => $query['meta_value'] ?? '',
+							'value'   => $this->map_date_functions( $query['meta_value'] ?? '' ),
 							'compare' => $query['meta_compare'] ?? '',
 							'type'    => $query['meta_type'] ?? '',
 						)
@@ -45,7 +41,7 @@ trait Meta_Query {
 	 * @param string $value Argument to be passed to WP_Meta_Query.
 	 */
 	protected function map_date_functions( $value ) {
-		$value = str_ireplace(
+		return str_ireplace(
 			[
 				'NOW()',
 				'HOUR()',
@@ -66,7 +62,5 @@ trait Meta_Query {
 			],
 			$value
 		);
-	
-		return $value;
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,8 @@ Curate a list of posts to exclude from the query.
 
 Generate complicated post meta queries using an interface that allows you to create a query based on `meta_key`, `meta_value` and the `compare` options. Combine multiple queries and determine if they combine results (OR) or narrow them down (AND).
 
+You can use MySQL date functions as meta query values for dynamic queries. Supported functions are `NOW()`, `HOUR()`, `DAY()`, `MONTH()`, `YEAR()`, `WEEK()`, and `UNIX_TIMESTAMP()`.
+
 #### Date Query
 
 Query items before/after the current or selected or choose to show the post from the last 1, 3, 6 and 12 months.

--- a/readme.txt
+++ b/readme.txt
@@ -60,6 +60,7 @@ Create powerful meta queries without touching code:
 * **Flexible comparisons**: Use equals, not equals, greater than, less than, and more
 * **Logical operators**: Combine queries with AND/OR logic
 * **ACF integration**: Works seamlessly with Advanced Custom Fields
+* **Dynamic date functions**: Use MySQL date functions when casting meta as DATETIME
 
 ==== 📅 Dynamic Date Queries ====
 

--- a/tests/unit/Meta_Query_Tests.php
+++ b/tests/unit/Meta_Query_Tests.php
@@ -93,6 +93,33 @@ class Meta_Query_Tests extends TestCase {
 					),
 				),
 			),
+			'single query with dynamic date function'              => array(
+				// Custom data.
+				array(
+					'meta_query' => array(
+						'queries' => array(
+							array(
+								'meta_key'     => 'date',
+								'meta_value'   => 'YEAR()-MONTH()-DAY()',
+								'meta_compare' => '>=',
+								'meta_type'    => 'DATE',
+							),
+						),
+					),
+				),
+				// Expected results.
+				array(
+					'is_aql'     => true,
+					'meta_query' => array(
+						array(
+							'key'     => 'date',
+							'value'   => date( 'Y-m-d' ),
+							'compare' => '>=',
+							'type'    => 'DATE',
+						),
+					),
+				),
+			),
 			'single query without compare and type'     => array(
 				// Custom data.
 				array(


### PR DESCRIPTION
In some cases with a meta query you might want to build out a date query and use dynamic ranges, or make comparisons to date information for other purposes without necessarily casting values to date/time types. This is a little step in that direction that we've used in projects via a `pre_get_posts` filter, would be great to get your thoughts on the approach.