### PR TITLE
Add aql_query_id field to identify blocks in the aql_query_vars filter

### DIFF
--- a/extending-aql.md
+++ b/extending-aql.md
@@ -111,6 +111,28 @@ function aql_extension_show_current_author_only( $query_args, $block_query, $inh
 \add_filter( 'aql_query_vars', 'aql_extension_show_current_author_only', 10, 3 );
 ```
 
+#### Targeting a specific block
+
+Every AQL block has an optional Query identifier control. The value is stored in the `aql_query_id` query variable and is available in the `aql_query_vars` filter, making it easy to modify the query for a single block when a site contains multiple AQL blocks.
+
+```php
+/**
+ * Only modify the query for the block identified as `homepage-featured`.
+ *
+ * @param array   $query_args  Arguments to be passed to WP_Query.
+ * @param array   $block_query The query attribute retrieved from the block.
+ * @param boolean $inherited   Whether the query is being inherited.
+ */
+function aql_extension_target_homepage_featured( $query_args, $block_query, $inherited ) {
+	if ( isset( $block_query['aql_query_id'] ) && 'homepage-featured' === $block_query['aql_query_id'] ) {
+		$query_args['posts_per_page'] = 3;
+	}
+	return $query_args;
+}
+
+\add_filter( 'aql_query_vars', 'aql_extension_target_homepage_featured', 10, 3 );
+```
+
 ### Tutorial
 
 Using he example code above, you can make a custom extension plugin for AQL that will filter the displayed posts by author.

--- a/extending-aql.md
+++ b/extending-aql.md
@@ -113,7 +113,7 @@ function aql_extension_show_current_author_only( $query_args, $block_query, $inh
 
 #### Targeting a specific block
 
-Every AQL block has an optional Query identifier control. The value is stored in the `aql_query_id` query variable and is available in the `aql_query_vars` filter, making it easy to modify the query for a single block when a site contains multiple AQL blocks.
+Every AQL block has an optional Query identifier control. The value is stored in the `aql_query_id` query variable and is available in the `$block_query` parameter of the `aql_query_vars` filter (and in `$query_args` for non-inherited queries), making it easy to modify the query for a single block when a site contains multiple AQL blocks.
 
 ```php
 /**

--- a/includes/Query_Params_Generator.php
+++ b/includes/Query_Params_Generator.php
@@ -23,6 +23,7 @@ class Query_Params_Generator {
 	use Traits\Post_Parent;
 	use Traits\Enable_Caching;
 	use Traits\OrderBy;
+	use Traits\Query_Id;
 
 	/**
 	 * The list of allowed controls and their associated params in the query.
@@ -40,6 +41,7 @@ class Query_Params_Generator {
 		'pagination'               => 'disable_pagination',
 		'exclude_posts'            => 'exclude_posts',
 		'enable_caching'           => 'enable_caching',
+		'query_id'                 => 'aql_query_id',
 	);
 
 

--- a/includes/Traits/Query_Id.php
+++ b/includes/Traits/Query_Id.php
@@ -8,6 +8,18 @@ namespace AdvancedQueryLoop\Traits;
 trait Query_Id {
 
 	public function process_aql_query_id() {
-		$this->custom_args['aql_query_id'] = $this->get_custom_param( 'aql_query_id' );
+		$query_id = $this->get_custom_param( 'aql_query_id' );
+
+		// Only accept a non-empty string identifier.
+		if ( ! is_string( $query_id ) ) {
+			return;
+		}
+
+		$query_id = trim( $query_id );
+		if ( '' === $query_id ) {
+			return;
+		}
+
+		$this->custom_args['aql_query_id'] = $query_id;
 	}
 }

--- a/includes/Traits/Query_Id.php
+++ b/includes/Traits/Query_Id.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Trait for managing the query identifier.
+ */
+
+namespace AdvancedQueryLoop\Traits;
+
+trait Query_Id {
+
+	public function process_aql_query_id() {
+		$this->custom_args['aql_query_id'] = $this->get_custom_param( 'aql_query_id' );
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,7 @@ add_filter(
 -   `'date_query_relationship'`
 -   `'pagination'`
 -   `'enable_caching'`
+-   `'query_id'`
 
 ## Extending AQL
 

--- a/readme.txt
+++ b/readme.txt
@@ -123,6 +123,7 @@ add_filter(
 * `'date_query_relationship'` - Date query logic
 * `'pagination'` - Pagination controls
 * `'enable_caching'` - Query result caching
+* `'query_id'` - Query identifier for targeting a specific block in the `aql_query_vars` filter
 
 ==== Developer-Friendly ====
 

--- a/src/components/query-id-control.js
+++ b/src/components/query-id-control.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+export const QueryIdControl = ( {
+	attributes,
+	setAttributes,
+	allowedControls,
+} ) => {
+	const { query: { aql_query_id: queryId } = {} } = attributes;
+
+	// If the control is not allowed, return null.
+	if ( ! allowedControls.includes( 'query_id' ) ) {
+		return null;
+	}
+
+	return (
+		<TextControl
+			__next40pxDefaultSize
+			__nextHasNoMarginBottom
+			label={ __( 'Query identifier', 'advanced-query-loop' ) }
+			help={ __(
+				'An optional identifier for this query. Available in the aql_query_vars filter to target this block.',
+				'advanced-query-loop'
+			) }
+			value={ queryId ?? '' }
+			onChange={ ( value ) =>
+				setAttributes( {
+					query: {
+						...attributes.query,
+						aql_query_id: value !== '' ? value : undefined,
+					},
+				} )
+			}
+		/>
+	);
+};

--- a/src/variations/controls.js
+++ b/src/variations/controls.js
@@ -31,6 +31,7 @@ import { PostIncludeControls } from '../components/post-include-controls';
 import { PaginationToggle } from '../components/pagination-toggle';
 import { ChildItemsToggle } from '../components/child-items-toggle';
 import { PerformanceControls } from '../components/performance-controls';
+import { QueryIdControl } from '../components/query-id-control';
 
 /**
  * Determines if the active variation is this one
@@ -62,6 +63,7 @@ const ALL_CONTROLS = [
 	'pagination',
 	'exclude_posts',
 	'enable_caching',
+	'query_id',
 ];
 
 /**
@@ -119,6 +121,7 @@ const withAdvancedQueryControls = ( BlockEdit ) => ( props ) => {
 								fillProps={ { ...propsWithControls } }
 							/>
 
+							<QueryIdControl { ...propsWithControls } />
 							<MultiplePostSelect { ...propsWithControls } />
 							<BaseControl
 								label={ __(
@@ -162,6 +165,7 @@ const withAdvancedQueryControls = ( BlockEdit ) => ( props ) => {
 							'advanced-query-loop'
 						) }
 					>
+						<QueryIdControl { ...propsWithControls } />
 						<PostOrderControls { ...propsWithControls } />
 						<AQLControlsInheritedQuery.Slot
 							fillProps={ { ...propsWithControls } }

--- a/tests/unit/Enable_Caching_Tests.php
+++ b/tests/unit/Enable_Caching_Tests.php
@@ -287,11 +287,9 @@ class Enable_Caching_Tests extends TestCase {
 
 		$result = $qpg->get_query_args();
 
-		// Condition 1: isset( $query->query['is_aql'] )
 		$this->assertArrayHasKey( 'is_aql', $result );
 		$this->assertSame( true, $result['is_aql'] );
 
-		// Condition 2: true === $query->query['enable_caching']
 		$this->assertArrayHasKey( 'enable_caching', $result );
 		$this->assertSame( true, $result['enable_caching'] );
 	}

--- a/tests/unit/Query_Id_Tests.php
+++ b/tests/unit/Query_Id_Tests.php
@@ -42,7 +42,22 @@ class Query_Id_Tests extends TestCase {
 				// Expected - null is falsy, not processed.
 				array( 'is_aql' => true ),
 			),
-		);
+			'whitespace aql_query_id'   => array(
+				// Custom data.
+				array(
+					'aql_query_id' => '   ',
+				),
+				// Expected - whitespace-only should be treated as empty.
+				array( 'is_aql' => true ),
+			),
+			'array aql_query_id'        => array(
+				// Custom data.
+				array(
+					'aql_query_id' => array( 'not-a-string' ),
+				),
+				// Expected - non-scalar values should be ignored.
+				array( 'is_aql' => true ),
+			),
 	}
 
 	/**

--- a/tests/unit/Query_Id_Tests.php
+++ b/tests/unit/Query_Id_Tests.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Tests for the Query_Id Trait
+ */
+
+namespace AdvancedQueryLoop\UnitTests;
+
+use AdvancedQueryLoop\Query_Params_Generator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Test the Query_Id trait
+ */
+class Query_Id_Tests extends TestCase {
+
+	/**
+	 * Data provider for tests that should not add aql_query_id
+	 *
+	 * @return array
+	 */
+	public function data_no_query_id() {
+		return array(
+			'no aql_query_id param'     => array(
+				// Custom data.
+				array(),
+				// Expected.
+				array( 'is_aql' => true ),
+			),
+			'empty string aql_query_id' => array(
+				// Custom data.
+				array(
+					'aql_query_id' => '',
+				),
+				// Expected - empty string is falsy, not processed.
+				array( 'is_aql' => true ),
+			),
+			'null aql_query_id'         => array(
+				// Custom data.
+				array(
+					'aql_query_id' => null,
+				),
+				// Expected - null is falsy, not processed.
+				array( 'is_aql' => true ),
+			),
+		);
+	}
+
+	/**
+	 * Test that empty/null identifier values are not added
+	 *
+	 * @param array $custom_data The params coming from AQL.
+	 * @param array $expected    The expected results.
+	 *
+	 * @dataProvider data_no_query_id
+	 */
+	public function test_query_id_empty_handling( $custom_data, $expected ) {
+		$qpg = new Query_Params_Generator( array(), $custom_data );
+		$qpg->process_all();
+
+		$this->assertEquals( $expected, $qpg->get_query_args() );
+	}
+
+	/**
+	 * Test that the identifier is passed through to the query args
+	 */
+	public function test_query_id_passed_through() {
+		$qpg = new Query_Params_Generator( array(), array( 'aql_query_id' => 'homepage-featured' ) );
+		$qpg->process_all();
+
+		$this->assertEquals(
+			array(
+				'is_aql'       => true,
+				'aql_query_id' => 'homepage-featured',
+			),
+			$qpg->get_query_args()
+		);
+	}
+
+	/**
+	 * Test the identifier works alongside other query params
+	 */
+	public function test_query_id_with_other_params() {
+		$custom_data = array(
+			'aql_query_id'    => 'sidebar-recent',
+			'exclude_current' => 20,
+		);
+
+		$qpg = new Query_Params_Generator( array(), $custom_data );
+		$qpg->process_all();
+
+		$result = $qpg->get_query_args();
+
+		$this->assertSame( 'sidebar-recent', $result['aql_query_id'] );
+		$this->assertEquals( array( 20 ), $result['post__not_in'] );
+	}
+
+	/**
+	 * Test that query_id is registered as an allowed control
+	 */
+	public function test_query_id_is_an_allowed_control() {
+		$this->assertContains( 'query_id', Query_Params_Generator::get_allowed_controls() );
+	}
+}

--- a/tests/unit/Query_Id_Tests.php
+++ b/tests/unit/Query_Id_Tests.php
@@ -58,6 +58,7 @@ class Query_Id_Tests extends TestCase {
 				// Expected - non-scalar values should be ignored.
 				array( 'is_aql' => true ),
 			),
+		);
 	}
 
 	/**


### PR DESCRIPTION
Adds a Query identifier text control that stores an aql_query_id string in the block's query attribute, making it available in both the $query_args and $block_query parameters of the aql_query_vars filter so individual AQL blocks can be targeted.

Fixes #122