### PR TITLE
Fix: never disable the Meta Query builder on sampled-post meta detection

### DIFF
--- a/src/components/post-meta-query-controls.js
+++ b/src/components/post-meta-query-controls.js
@@ -77,7 +77,6 @@ export const PostMetaQueryControls = ( {
 						onClick={ onToggle }
 						aria-haspopup="true"
 						aria-expanded={ isOpen }
-						disabled={ Object.keys( registeredMeta ).length === 0 }
 					>
 						{ isOpen
 							? __(

--- a/src/components/post-meta-query-controls.js
+++ b/src/components/post-meta-query-controls.js
@@ -39,7 +39,7 @@ export const PostMetaQueryControls = ( {
 		} = {},
 	} = attributes;
 
-	const registeredMeta = usePostTypeMetaFields( [
+	const registeredMetaKeys = usePostTypeMetaFields( [
 		postType,
 		...multiplePosts,
 	] );
@@ -153,9 +153,9 @@ export const PostMetaQueryControls = ( {
 												metaKey={ metaKey }
 												metaValue={ metaValue }
 												metaCompare={ compare }
-												registeredMetaKeys={ Object.keys(
-													registeredMeta
-												) }
+												registeredMetaKeys={
+													registeredMetaKeys
+												}
 												queries={ queries }
 												attributes={ attributes }
 												setAttributes={ setAttributes }

--- a/src/hooks/usePostTypeMetaFields.js
+++ b/src/hooks/usePostTypeMetaFields.js
@@ -9,18 +9,20 @@ const usePostTypeMetaFields = ( postTypes ) => {
 				return meta;
 			}
 			postTypes.filter( Boolean ).forEach( ( type ) => {
-				const postInstance = select( coreDataStore ).getEntityRecords(
+				// Sample several posts — any single post may have no saved
+				// meta even when the post type uses it.
+				const postInstances = select( coreDataStore ).getEntityRecords(
 					'postType',
 					type,
-					{ per_page: 1 }
+					{ per_page: 10 }
 				);
-				if ( postInstance && postInstance?.[ 0 ]?.meta !== undefined ) {
+				( postInstances ?? [] ).forEach( ( postInstance ) => {
 					meta = {
 						...meta,
-						...postInstance?.[ 0 ]?.meta,
-						...postInstance?.[ 0 ]?.acf, // Include ACF fields if ACF is active
+						...( postInstance?.meta ?? {} ),
+						...( postInstance?.acf ?? {} ), // Include ACF fields if ACF is active
 					};
-				}
+				} );
 			} );
 			return meta;
 		},

--- a/src/hooks/usePostTypeMetaFields.js
+++ b/src/hooks/usePostTypeMetaFields.js
@@ -4,9 +4,9 @@ import { store as coreDataStore } from '@wordpress/core-data';
 const usePostTypeMetaFields = ( postTypes ) => {
 	return useSelect(
 		( select ) => {
-			let meta = {};
+			const keys = new Set();
 			if ( ! Array.isArray( postTypes ) || postTypes.length === 0 ) {
-				return meta;
+				return [];
 			}
 			postTypes.filter( Boolean ).forEach( ( type ) => {
 				// Sample several posts — any single post may have no saved
@@ -17,14 +17,16 @@ const usePostTypeMetaFields = ( postTypes ) => {
 					{ per_page: 10 }
 				);
 				( postInstances ?? [] ).forEach( ( postInstance ) => {
-					meta = {
-						...meta,
-						...( postInstance?.meta ?? {} ),
-						...( postInstance?.acf ?? {} ), // Include ACF fields if ACF is active
-					};
+					Object.keys( postInstance?.meta ?? {} ).forEach( ( key ) =>
+						keys.add( key )
+					);
+					// Include ACF fields if ACF is active.
+					Object.keys( postInstance?.acf ?? {} ).forEach( ( key ) =>
+						keys.add( key )
+					);
 				} );
 			} );
-			return meta;
+			return [ ...keys ];
 		},
 		[ postTypes ]
 	);


### PR DESCRIPTION
Fixes #171. Support report: https://wordpress.org/support/topic/cant-query-cpt-by-taxonomy-anymore/

The 4.4.0 meta-key detection gated the builder button on the `meta`/`acf` keys of a single sampled post (`per_page: 1`). If the newest post of a CPT had no saved meta/ACF values, the builder was disabled for that post type — blocking edits to existing `meta_query` config that still worked on the frontend.

- The builder button is always enabled; detected keys are suggestions only (`FormTokenField` accepts free-text keys, matching pre-4.4.0 behavior)
- `usePostTypeMetaFields` samples 10 posts per type and merges keys across them
- ACF keys are spread even when the REST response has no `meta` field (previously nested inside the `meta !== undefined` guard)