### PR TITLE
ci: skip e2e and PHPUnit runs when no relevant files changed

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,34 @@ on:
         branches: ['trunk']
 
 jobs:
+    changes:
+        runs-on: ubuntu-latest
+        outputs:
+            code: ${{ steps.filter.outputs.code }}
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Check for changes that affect e2e tests
+              uses: dorny/paths-filter@v3
+              id: filter
+              with:
+                  filters: |
+                      code:
+                          - 'src/**'
+                          - 'includes/**'
+                          - 'tests/e2e/**'
+                          - 'index.php'
+                          - 'package.json'
+                          - 'package-lock.json'
+                          - 'composer.json'
+                          - 'composer.lock'
+                          - 'webpack.config.js'
+                          - 'tsconfig.json'
+                          - '.github/workflows/e2e.yml'
+
     e2e:
+        needs: changes
+        if: needs.changes.outputs.code == 'true'
         runs-on: ubuntu-latest
 
         steps:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   changes:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -10,8 +10,30 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      php: ${{ steps.filter.outputs.php }}
+    steps:
+    - uses: actions/checkout@v4
 
+    - name: Check for changes that affect PHPUnit tests
+      uses: dorny/paths-filter@v3
+      id: filter
+      with:
+        filters: |
+          php:
+            - 'includes/**'
+            - 'tests/unit/**'
+            - 'index.php'
+            - 'composer.json'
+            - 'composer.lock'
+            - 'phpunit.xml'
+            - '.github/workflows/phpunit.yml'
+
+  build:
+    needs: changes
+    if: needs.changes.outputs.php == 'true'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## What

Adds a lightweight `changes` job (using [`dorny/paths-filter@v3`](https://github.com/dorny/paths-filter)) to both the E2E and PHPUnit workflows, and gates the actual test jobs on its output.

## Why

E2E tests are the most expensive part of CI, but they currently run on every PR — including ones that only touch docs, readmes, or blueprints. Trigger-level `paths:` filtering was avoided because a workflow that never starts leaves a required check pending forever. With this pattern the workflow always runs, the ~5s filter job decides, and a skipped test job reports a **passing** conclusion — so merges are never blocked.

## Filters

- **E2E** runs when any of these change: `src/**`, `includes/**`, `tests/e2e/**`, `index.php`, `package.json`, `package-lock.json`, `composer.json`, `composer.lock`, `webpack.config.js`, `tsconfig.json`, or the workflow itself.
- **PHPUnit** runs for: `includes/**`, `tests/unit/**`, `index.php`, `composer.json`, `composer.lock`, `phpunit.xml`, or the workflow itself.

Everything else (docs, readmes, `_blueprints/`, etc.) skips both suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WkFWTi6bDr6GUcuePXbAAG